### PR TITLE
Feature/wrap logging

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -1,11 +1,12 @@
 #include "Aquarius.h"
-
-INITIALIZE_EASYLOGGINGPP
+#include "Aquarius/Core/Log.h"
 
 namespace Aquarius {
 
 int Test::testMain()
 {
+    Log::initLoggers();
+
     glfwInit();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
@@ -14,17 +15,20 @@ int Test::testMain()
     GLFWwindow* window = glfwCreateWindow(800, 600, "Aquarius-Test", NULL, NULL);
     if (window == NULL)
     {
-        AQ_LOG_WARNING << "Could not create window";
+        AQ_WARNING("Could not create window");
     }
     glfwMakeContextCurrent(window);
 
     if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
     {
-        AQ_LOG_WARNING << "Could not initialize glad";
+        AQ_WARNING("Could not initialize glad");
         return -1;
     }
 
-    AQ_LOG_INFO << "Window created successfully!";
+    AQ_INFO("Window created successfully!");
+
+    AQ_INFO("Testing %v %v", "client", "logger");
+    AQ_CORE_INFO("Testing %v %v", "core", "logger");
 
     while (!glfwWindowShouldClose(window))
     {

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -6,8 +6,6 @@
 #include <stb_image.h>
 #include <glm/glm.hpp>
 
-#define AQ_LOG_INFO LOG(INFO)
-#define AQ_LOG_WARNING LOG(WARNING)
 
 namespace Aquarius {
     class Test

--- a/Aquarius/CMakeLists.txt
+++ b/Aquarius/CMakeLists.txt
@@ -5,9 +5,11 @@ project(Aquarius-Engine)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(sources Aquarius.cpp Aquarius.h)
+file(GLOB_RECURSE Sources "Src/*.cpp" "Src/*.h")
 
-add_library(Aquarius-Engine STATIC ${sources})
+include_directories(Src/)
+
+add_library(Aquarius-Engine STATIC ${Sources} Aquarius.cpp Aquarius.h)
 
 target_link_libraries(Aquarius-Engine glad)
 target_link_libraries(Aquarius-Engine glfw ${GLFW_LIBRARIES})

--- a/Aquarius/Src/Aquarius/Core/Log.cpp
+++ b/Aquarius/Src/Aquarius/Core/Log.cpp
@@ -1,0 +1,29 @@
+#include "Log.h"
+
+INITIALIZE_EASYLOGGINGPP
+
+namespace Aquarius {
+
+	el::Logger* Log::s_clientLogger;
+	el::Logger* Log::s_coreLogger;
+
+	void Log::initLoggers()
+	{
+		el::Configurations coreConfig;
+		el::Configurations clientConfig;
+		
+		el::Loggers::addFlag(el::LoggingFlag::MultiLoggerSupport);
+
+		coreConfig.set(el::Level::Global, el::ConfigurationType::Format, "AQ_CORE %level [%datetime] - %msg");
+		coreConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+		
+		clientConfig.set(el::Level::Global, el::ConfigurationType::Format, "%level [%datetime] - %msg");
+		clientConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+
+		s_coreLogger = el::Loggers::getLogger("Core");
+		s_clientLogger = el::Loggers::getLogger("Client");
+
+		el::Loggers::reconfigureLogger("Core", coreConfig);
+		el::Loggers::reconfigureLogger("Client", clientConfig);
+	}
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Log.h
+++ b/Aquarius/Src/Aquarius/Core/Log.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "easylogging++.h"
+
+// Note: for printf-like formatting, use only %v instead of type specific identifiers within log string
+
+// Core log macros
+#define AQ_CORE_TRACE(String, ...)      ::Aquarius::Log::getCoreLogger()->trace(String, __VA_ARGS__);
+#define AQ_CORE_INFO(String, ...)       ::Aquarius::Log::getCoreLogger()->info(String, __VA_ARGS__);
+#define AQ_CORE_WARNING(String, ...)    ::Aquarius::Log::getCoreLogger()->warn(String, __VA_ARGS__);
+#define AQ_CORE_ERROR(String, ...)      ::Aquarius::Log::getCoreLogger()->error(String, __VA_ARGS__);
+#define AQ_CORE_FATAL(String, ...)      ::Aquarius::Log::getCoreLogger()->fatal(String, __VA_ARGS__);
+
+// Client log macros
+#define AQ_TRACE(String, ...)           ::Aquarius::Log::getClientLogger()->trace(String, __VA_ARGS__);
+#define AQ_INFO(String, ...)            ::Aquarius::Log::getClientLogger()->info(String, __VA_ARGS__);
+#define AQ_WARNING(String, ...)         ::Aquarius::Log::getClientLogger()->warn(String, __VA_ARGS__);
+#define AQ_ERROR(String, ...)           ::Aquarius::Log::getClientLogger()->error(String, __VA_ARGS__);
+#define AQ_FATAL(String, ...)           ::Aquarius::Log::getClientLogger()->fatal(String, __VA_ARGS__);
+
+
+namespace Aquarius {
+
+	class Log
+	{
+	public:
+		static void initLoggers();
+
+		static el::Logger* getClientLogger() { return s_clientLogger; }
+		static el::Logger* getCoreLogger() { return s_coreLogger; }
+	private:
+		Log() = delete;
+
+		static el::Logger* s_clientLogger;
+		static el::Logger* s_coreLogger;
+	};
+} // namespace Aquarius


### PR DESCRIPTION
This PR contains a Log class which wraps the logging functionality of easylogging++ to provide a core logger instance to be used within the engine for logging, and a client logger instance to be used by developers utilizing the engine to log within their application.

One thing I have not implemented yet is the ability to set the log level (i.e. setting log level so that anything below the set log level will not be logged to the console). Easylogging++ is a bit weird in that it does not hierarchically log by default, but I feel like it would be pretty easy to add this functionality within the Log wrapper.

We should discuss and then subsequently implement if necessary.