### PR TITLE
Fix error with macro expansion on GCC

### DIFF
--- a/Aquarius/Src/Aquarius/Core/Log.h
+++ b/Aquarius/Src/Aquarius/Core/Log.h
@@ -5,18 +5,18 @@
 // Note: for printf-like formatting, use only %v instead of type specific identifiers within log string
 
 // Core log macros
-#define AQ_CORE_TRACE(String, ...)      ::Aquarius::Log::getCoreLogger()->trace(String, __VA_ARGS__);
-#define AQ_CORE_INFO(String, ...)       ::Aquarius::Log::getCoreLogger()->info(String, __VA_ARGS__);
-#define AQ_CORE_WARNING(String, ...)    ::Aquarius::Log::getCoreLogger()->warn(String, __VA_ARGS__);
-#define AQ_CORE_ERROR(String, ...)      ::Aquarius::Log::getCoreLogger()->error(String, __VA_ARGS__);
-#define AQ_CORE_FATAL(String, ...)      ::Aquarius::Log::getCoreLogger()->fatal(String, __VA_ARGS__);
+#define AQ_CORE_TRACE(String, ...)      ::Aquarius::Log::getCoreLogger()->trace(String, ##__VA_ARGS__)
+#define AQ_CORE_INFO(String, ...)       ::Aquarius::Log::getCoreLogger()->info(String, ##__VA_ARGS__)
+#define AQ_CORE_WARNING(String, ...)    ::Aquarius::Log::getCoreLogger()->warn(String, ##__VA_ARGS__)
+#define AQ_CORE_ERROR(String, ...)      ::Aquarius::Log::getCoreLogger()->error(String, ##__VA_ARGS__)
+#define AQ_CORE_FATAL(String, ...)      ::Aquarius::Log::getCoreLogger()->fatal(String, ##__VA_ARGS__)
 
 // Client log macros
-#define AQ_TRACE(String, ...)           ::Aquarius::Log::getClientLogger()->trace(String, __VA_ARGS__);
-#define AQ_INFO(String, ...)            ::Aquarius::Log::getClientLogger()->info(String, __VA_ARGS__);
-#define AQ_WARNING(String, ...)         ::Aquarius::Log::getClientLogger()->warn(String, __VA_ARGS__);
-#define AQ_ERROR(String, ...)           ::Aquarius::Log::getClientLogger()->error(String, __VA_ARGS__);
-#define AQ_FATAL(String, ...)           ::Aquarius::Log::getClientLogger()->fatal(String, __VA_ARGS__);
+#define AQ_TRACE(String, ...)           ::Aquarius::Log::getClientLogger()->trace(String, ##__VA_ARGS__)
+#define AQ_INFO(String, ...)            ::Aquarius::Log::getClientLogger()->info(String, ##__VA_ARGS__)
+#define AQ_WARNING(String, ...)         ::Aquarius::Log::getClientLogger()->warn(String, ##__VA_ARGS__)
+#define AQ_ERROR(String, ...)           ::Aquarius::Log::getClientLogger()->error(String, ##__VA_ARGS__)
+#define AQ_FATAL(String, ...)           ::Aquarius::Log::getClientLogger()->fatal(String, ##__VA_ARGS__)
 
 
 namespace Aquarius {


### PR DESCRIPTION
Fixes error @colton-smith was seeing on linux, basically MSVC was smart and when `__VA_ARGS__` is used with no arguments supplied, it omits the would be trailing comma from the macro expansion.

For example, `AQ_WARNING("Could not create window");` expands to `::Aquarius::Log::getClientLogger()->warn("Could not create window")` on windows but `::Aquarius::Log::getClientLogger()->warn("Could not create window", )` on linux(gcc). The fix to this is to include` ##` in front of `__VA_ARGS__`, which omits the comma if no arguments are supplied (MSVC preprocessor seems to do this automatically).

Also removed semicolons from macro definitions even though it didn't seem to be breaking anything