### PR TITLE
Assertion wrapper

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -1,3 +1,5 @@
+#define AQ_ASSERT_ENABLE
+
 #include "Aquarius.h"
 #include "Aquarius/Core/Log.h"
 #include "Aquarius/Core/Window.h"

--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -3,6 +3,8 @@
 #include "Aquarius.h"
 #include "Aquarius/Core/Log.h"
 #include "Aquarius/Core/Window.h"
+#include "Aquarius/Core/Assert.h"
+
 
 namespace Aquarius {
 

--- a/Aquarius/CMakeLists.txt
+++ b/Aquarius/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Aquarius-Engine)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 file(GLOB_RECURSE Sources "Src/*.cpp" "Src/*.h")

--- a/Aquarius/Src/Aquarius/Core/Assert.h
+++ b/Aquarius/Src/Aquarius/Core/Assert.h
@@ -12,6 +12,7 @@ inline void aqCoreAssert(bool expression)
 	if (!expression)
 	{
 		AQ_CORE_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
+		std::abort();
 	}
 	#endif
 }
@@ -24,6 +25,7 @@ inline void aqCoreAssert(bool expression, Msg message, Ts ... args)
 	{
 		std::string errorMessage = "Assertion failed: " + std::string(message);
 		AQ_ERROR(errorMessage.c_str(), args...);
+		std::abort();
 	}
 	#endif
 }
@@ -34,6 +36,7 @@ inline void aqAssert(bool expression)
 	if (!expression)
 	{
 		AQ_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
+		std::abort();
 	}
 	#endif
 }
@@ -46,6 +49,7 @@ inline void aqAssert(bool expression, Msg message, Ts ... args)
 	{
 		std::string errorMessage = "Assertion failed: " + std::string(message);
 		AQ_ERROR(errorMessage.c_str(), args...);
+		std::abort();
 	}
 	#endif
 }

--- a/Aquarius/Src/Aquarius/Core/Assert.h
+++ b/Aquarius/Src/Aquarius/Core/Assert.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Aquarius/Core/Log.h"
+
+#include <string>
+
+namespace Aquarius {
+
+inline void aqCoreAssert(bool expression)
+{
+	#ifdef AQ_ASSERT_ENABLE
+	if (!expression)
+	{
+		AQ_CORE_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
+	}
+	#endif
+}
+
+template<typename Msg, typename ... Ts>
+inline void aqCoreAssert(bool expression, Msg message, Ts ... args)
+{
+	#ifdef AQ_ASSERT_ENABLE
+	if (!expression)
+	{
+		std::string errorMessage = "Assertion failed: " + std::string(message);
+		AQ_ERROR(errorMessage.c_str(), args...);
+	}
+	#endif
+}
+
+inline void aqAssert(bool expression)
+{
+	#ifdef AQ_ASSERT_ENABLE
+	if (!expression)
+	{
+		AQ_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
+	}
+	#endif
+}
+
+template<typename Msg, typename ... Ts>
+inline void aqAssert(bool expression, Msg message, Ts ... args)
+{
+	#ifdef AQ_ASSERT_ENABLE
+	if (!expression)
+	{
+		std::string errorMessage = "Assertion failed: " + std::string(message);
+		AQ_ERROR(errorMessage.c_str(), args...);
+	}
+	#endif
+}
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Assert.h
+++ b/Aquarius/Src/Aquarius/Core/Assert.h
@@ -24,7 +24,7 @@ inline void aqCoreAssert(bool expression, Msg message, Ts ... args)
 	if (!expression)
 	{
 		std::string errorMessage = "Assertion failed: " + std::string(message);
-		AQ_ERROR(errorMessage.c_str(), args...);
+		AQ_CORE_ERROR(errorMessage.c_str(), args...);
 		std::abort();
 	}
 	#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_REQUIRED_FLAGS -std=c++17)
+
 project(Aquarius)
 
 include_directories(${PROJECT_SOURCE_DIR}/Aquarius)


### PR DESCRIPTION
This PR wraps assertions up with some variadic template magic. The assertions will only be compiled if `AQ_ASSERT_ENABLE` is defined, otherwise these are just functions with empty bodies (in other words, nothing).