### PR TITLE
Windowing and Rendering Context

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -1,44 +1,28 @@
 #include "Aquarius.h"
 #include "Aquarius/Core/Log.h"
+#include "Aquarius/Core/Window.h"
 
 namespace Aquarius {
 
-int Test::testMain()
-{
-    Log::initLoggers();
-
-    glfwInit();
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-    GLFWwindow* window = glfwCreateWindow(800, 600, "Aquarius-Test", NULL, NULL);
-    if (window == NULL)
+    int Test::testMain()
     {
-        AQ_WARNING("Could not create window");
+        Log::initLoggers();
+
+        std::unique_ptr<Window> Window = Window::Create(800, 600, "Aquarius");
+        Window->Initialize();
+
+        AQ_INFO("Testing %v %v", "client", "logger");
+        AQ_CORE_INFO("Testing %v %v", "core", "logger");
+
+        while (1)
+        {
+            glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            Window->OnUpdate();
+        }
+
+        return 0;
     }
-    glfwMakeContextCurrent(window);
-
-    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
-    {
-        AQ_WARNING("Could not initialize glad");
-        return -1;
-    }
-
-    AQ_INFO("Window created successfully!");
-
-    AQ_INFO("Testing %v %v", "client", "logger");
-    AQ_CORE_INFO("Testing %v %v", "core", "logger");
-
-    while (!glfwWindowShouldClose(window))
-    {
-        glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
-        glClear(GL_COLOR_BUFFER_BIT);
-        glfwSwapBuffers(window);
-        glfwPollEvents();
-    }
-
-    return 0;
-}
 
 } // namespace Aquarius
+

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -86,6 +86,9 @@ namespace Aquarius {
     void Window::Deallocate()
     {
         glfwDestroyWindow(m_Window);
+        glfwTerminate();
+
+        AQ_CORE_INFO("Window destroyed and GLFW terminated");
     }
 
     void Window::setVsync(bool enabled)

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -44,9 +44,8 @@ namespace Aquarius {
         m_Window = glfwCreateWindow(m_Width, m_Height, m_Name.c_str(), NULL, NULL);
         if (m_Window == nullptr)
         {
-            AQ_CORE_FATAL("Failed to create a glfw window");
             glfwTerminate();
-            assert(false);
+            AQ_CORE_FATAL("Failed to create a glfw window");
         }
 
         // Generate context

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -15,6 +15,13 @@ namespace Aquarius {
 
     void Window::Initialize()
     {
+        // Set GLFW error callback
+        glfwSetErrorCallback([](int error_code, const char* description)
+                             {
+                                 AQ_CORE_ERROR("GLFW Error Occurred:");
+                                 AQ_CORE_ERROR(description);
+                             });
+
         // Initialize GLFW
         int initSuccess = glfwInit();
         if (!initSuccess)

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -5,7 +5,12 @@
 namespace Aquarius {
 
     Window::Window(uint32_t width, uint32_t height, std::string &&name, bool vsync)
-        : m_Width(width), m_Height(height), m_Name(std::move(name)), m_VsyncEnabled(vsync), m_Window(nullptr), m_Context(nullptr)
+        : m_Width(width),
+          m_Height(height),
+          m_Name(std::move(name)),
+          m_VsyncEnabled(vsync),
+          m_Window(nullptr),
+          m_Context(nullptr)
     {}
 
     Window::WindowPtr Window::Create(uint32_t width, uint32_t height, std::string &&name, bool vsync)
@@ -106,7 +111,7 @@ namespace Aquarius {
         }
         else
         {
-            glfwSwapInterval(1);
+            glfwSwapInterval(0);
             AQ_CORE_INFO("Vsync disabled");
         }
         m_VsyncEnabled = enabled;

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -73,7 +73,7 @@ namespace Aquarius {
         return m_Name;
     }
 
-    bool Window::getVsync() const
+    bool Window::isVsyncEnabled() const
     {
         return m_VsyncEnabled;
     }

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -1,0 +1,106 @@
+#include "Window.h"
+#include "Log.h"
+#include <assert.h>
+
+namespace Aquarius {
+
+    Window::Window(uint32_t width, uint32_t height, std::string &&name, bool vsync)
+        : m_Width(width), m_Height(height), m_Name(std::move(name)), m_VsyncEnabled(vsync), m_Window(nullptr), m_Context(nullptr)
+    {}
+
+    Window::WindowPtr Window::Create(uint32_t width, uint32_t height, std::string &&name, bool vsync)
+    {
+        return std::make_unique<Window>(width, height, std::move(name));
+    }
+
+    void Window::Initialize()
+    {
+        // Initialize GLFW
+        int initSuccess = glfwInit();
+        if (!initSuccess)
+        {
+            AQ_CORE_FATAL("Failed to initialize GLFW");
+        }
+        else
+        {
+            AQ_CORE_INFO("GLFW successfully initialized");
+        }
+
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+        #ifdef PLATFORM_MAC
+                glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+        #endif // PLATFORM_MAC
+
+        m_Window = glfwCreateWindow(m_Width, m_Height, m_Name.c_str(), NULL, NULL);
+        if (m_Window == nullptr)
+        {
+            AQ_CORE_FATAL("Failed to create a glfw window");
+            glfwTerminate();
+            assert(false);
+        }
+
+        // Generate context
+        m_Context = RenderingContext::Create(m_Window);
+        m_Context->Initialize();
+
+        glViewport(0, 0, m_Width, m_Height);
+        setVsync(m_VsyncEnabled);
+
+        // Register Window Callbacks here
+    }
+
+    uint32_t Window::getWidth() const
+    {
+        return m_Width;
+    }
+
+    uint32_t Window::getHeight() const
+    {
+        return m_Height;
+    }
+
+    const std::string& Window::getName() const
+    {
+        return m_Name;
+    }
+
+    bool Window::getVsync() const
+    {
+        return m_VsyncEnabled;
+    }
+
+    void Window::OnUpdate()
+    {
+        m_Context->SwapBuffers();
+        glfwPollEvents();
+    }
+
+    Window::~Window()
+    {
+        Deallocate();
+    }
+
+    void Window::Deallocate()
+    {
+        glfwDestroyWindow(m_Window);
+    }
+
+    void Window::setVsync(bool enabled)
+    {
+        if (enabled)
+        {
+            glfwSwapInterval(1);
+            AQ_CORE_INFO("Vsync enabled");
+        }
+        else
+        {
+            glfwSwapInterval(1);
+            AQ_CORE_INFO("Vsync disabled");
+        }
+        m_VsyncEnabled = enabled;
+    }
+
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -26,7 +26,7 @@ namespace Aquarius {
         uint32_t getWidth() const;
         uint32_t getHeight() const;
         const std::string& getName() const;
-        bool getVsync() const;
+        bool isVsyncEnabled() const;
         void setVsync(bool enabled);
 
         // Destruction

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <string>
+#include <memory>
+#include <Aquarius/Renderer/RenderingContext.h>
+#include <GLFW/glfw3.h>
+
+namespace Aquarius {
+
+    // GLFW Window
+    class Window
+    {
+        using WindowPtr = std::unique_ptr<Window>;
+
+    public:
+        // Creation
+        Window(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);
+        static WindowPtr Create(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);
+
+        // Initialize GLFW
+        void Initialize();
+
+        // Poll inputs and swap buffers
+        void OnUpdate();
+
+        // Utility methods
+        uint32_t getWidth() const;
+        uint32_t getHeight() const;
+        const std::string& getName() const;
+        bool getVsync() const;
+        void setVsync(bool enabled);
+
+        // Destruction
+        ~Window();
+
+    private:
+        uint32_t m_Width;
+        uint32_t m_Height;
+        const std::string m_Name;
+        bool m_VsyncEnabled;
+        GLFWwindow* m_Window;
+        std::unique_ptr<RenderingContext> m_Context;
+
+        // Deallocate window resources
+        void Deallocate();
+    };
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -20,13 +20,6 @@ namespace Aquarius {
         if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
         {
             AQ_CORE_FATAL("Failed to initialize GLAD" );
-
-            // Set GLFW error callback
-            glfwSetErrorCallback([](int error_code, const char* description)
-            {
-                AQ_CORE_ERROR("GLFW Error Occurred:");
-                AQ_CORE_ERROR(description);
-            });
         }
         else
         {

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -1,0 +1,56 @@
+#include "RenderingContext.h"
+#include <Aquarius/Core/Log.h>
+
+
+namespace Aquarius {
+
+    RenderingContext::RenderingContext(GLFWwindow* window)
+    :   m_Window(window)
+    {}
+
+    RenderingContext::ContextPtr RenderingContext::Create(GLFWwindow *window)
+    {
+        return std::make_unique<RenderingContext>(window);
+    }
+
+    void RenderingContext::Initialize()
+    {
+        // Use GLAD to load opengl function pointers
+        glfwMakeContextCurrent(m_Window);
+        if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
+        {
+            AQ_CORE_FATAL("Failed to initialize GLAD" );
+
+            // Set GLFW error callback
+            glfwSetErrorCallback([](int error_code, const char* description)
+            {
+                AQ_CORE_ERROR("GLFW Error Occurred:");
+                AQ_CORE_ERROR(description);
+            });
+        }
+        else
+        {
+            AQ_CORE_INFO("GLAD successfully initialized");
+        }
+
+        AQ_CORE_INFO("Vendor: %v", glGetString(GL_VENDOR));
+        AQ_CORE_INFO("GPU: %v", glGetString(GL_RENDERER));
+        AQ_CORE_INFO("OpenGL Version: %v", glGetString(GL_VERSION));
+    }
+
+    void RenderingContext::SwapBuffers()
+    {
+        glfwSwapBuffers(m_Window);
+    }
+
+    void RenderingContext::Deallocate()
+    {
+        glfwTerminate();
+    }
+
+    RenderingContext::~RenderingContext()
+    {
+        Deallocate();
+    }
+
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -42,15 +42,4 @@ namespace Aquarius {
     {
         glfwSwapBuffers(m_Window);
     }
-
-    void RenderingContext::Deallocate()
-    {
-        glfwTerminate();
-    }
-
-    RenderingContext::~RenderingContext()
-    {
-        Deallocate();
-    }
-
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+#include <memory>
+
+namespace Aquarius {
+
+    // OpenGL Rendering Context
+    class RenderingContext
+    {
+        using ContextPtr = std::unique_ptr<RenderingContext>;
+    public:
+        RenderingContext(GLFWwindow* window);
+        static ContextPtr Create(GLFWwindow* window);
+
+        void Initialize();
+        void SwapBuffers();
+
+        void Deallocate();
+        ~RenderingContext();
+
+    private:
+        GLFWwindow* m_Window;
+    };
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
@@ -16,9 +16,6 @@ namespace Aquarius {
         void Initialize();
         void SwapBuffers();
 
-        void Deallocate();
-        ~RenderingContext();
-
     private:
         GLFWwindow* m_Window;
     };

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.10)
 project(Aquarius)
 
 include_directories(${PROJECT_SOURCE_DIR}/Aquarius)
+include_directories(${PROJECT_SOURCE_DIR}/Aquarius/Src)
 include_directories(${PROJECT_SOURCE_DIR}/Aquarius/Vendor/glfw/include)
 include_directories(${PROJECT_SOURCE_DIR}/Aquarius/Vendor/glad/include)
 include_directories(${PROJECT_SOURCE_DIR}/Aquarius/Vendor/easyloggingpp/src)
 include_directories(${PROJECT_SOURCE_DIR}/Aquarius/Vendor/stb_image)
-include_directories(${GLM_INCLUDE_DIRS})
 
 # So that easylogging++ is build as a static lib
 set(build_static_lib ON CACHE BOOL "build static library" FORCE)
@@ -15,6 +15,7 @@ set(build_static_lib ON CACHE BOOL "build static library" FORCE)
 # Find GLM
 set(glm_DIR Aquarius/Vendor/glm/cmake/glm)
 find_package(glm REQUIRED)
+include_directories(${GLM_INCLUDE_DIRS})
 
 # Add other subprojects
 add_subdirectory(Aquarius)


### PR DESCRIPTION
This PR adds an initial (mostly complete) implementation of a `Window` class and a `RenderingContext` class. Their lifetime are tied, by way of Window having a unique pointer to a rendering context. Other than readability / making it easier to abstract down the road, these could have been just one class. 

Importantly:
- `Window` handles window creation 
- `RenderingContext` loads OpenGL symbols and sets current context to the created window
- `Window` destructor destroys the glfw window and terminates glfw
- Vsync can be enabled/disabled 

TODO
- Register callbacks
