### PR TITLE
Logging refinement

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -2,10 +2,7 @@
 
 #include "Aquarius.h"
 #include "Aquarius/Core/Log.h"
-<<<<<<< HEAD
 #include "Aquarius/Core/Window.h"
-=======
->>>>>>> fbc90d4 (Update testMain to include example assertions)
 #include "Aquarius/Core/Assert.h"
 
 

--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -2,7 +2,10 @@
 
 #include "Aquarius.h"
 #include "Aquarius/Core/Log.h"
+<<<<<<< HEAD
 #include "Aquarius/Core/Window.h"
+=======
+>>>>>>> fbc90d4 (Update testMain to include example assertions)
 #include "Aquarius/Core/Assert.h"
 
 

--- a/Aquarius/Src/Aquarius/Core/Log.cpp
+++ b/Aquarius/Src/Aquarius/Core/Log.cpp
@@ -7,23 +7,89 @@ namespace Aquarius {
 	el::Logger* Log::s_clientLogger;
 	el::Logger* Log::s_coreLogger;
 
+	el::Configurations Log::s_clientConfig;
+	el::Configurations Log::s_coreConfig;
+
 	void Log::initLoggers()
 	{
-		el::Configurations coreConfig;
-		el::Configurations clientConfig;
-		
 		el::Loggers::addFlag(el::LoggingFlag::MultiLoggerSupport);
 
-		coreConfig.set(el::Level::Global, el::ConfigurationType::Format, "AQ_CORE %level [%datetime] - %msg");
-		coreConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+		s_coreConfig.set(el::Level::Global, el::ConfigurationType::Format, "AQ_CORE %level [%datetime] - %msg");
+		s_coreConfig.set(el::Level::Global, el::ConfigurationType::ToFile, "false");
+		s_coreConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+		s_coreConfig.set(el::Level::Debug, el::ConfigurationType::Enabled, "false");
+		s_coreConfig.set(el::Level::Verbose, el::ConfigurationType::Enabled, "false");
 		
-		clientConfig.set(el::Level::Global, el::ConfigurationType::Format, "%level [%datetime] - %msg");
-		clientConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+		s_clientConfig.set(el::Level::Global, el::ConfigurationType::Format, "%level [%datetime] - %msg");
+		s_clientConfig.set(el::Level::Global, el::ConfigurationType::ToFile, "false");
+		s_clientConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+		s_clientConfig.set(el::Level::Debug, el::ConfigurationType::Enabled, "false");
+		s_clientConfig.set(el::Level::Verbose, el::ConfigurationType::Enabled, "false");
 
 		s_coreLogger = el::Loggers::getLogger("Core");
 		s_clientLogger = el::Loggers::getLogger("Client");
 
-		el::Loggers::reconfigureLogger("Core", coreConfig);
-		el::Loggers::reconfigureLogger("Client", clientConfig);
+		el::Loggers::reconfigureLogger("Core", s_coreConfig);
+		el::Loggers::reconfigureLogger("Client", s_clientConfig);
 	}
+
+	void Log::setClientLogFile(const std::string& fileName)
+	{
+		s_clientConfig.set(el::Level::Global, el::ConfigurationType::ToFile, "true");
+		s_clientConfig.set(el::Level::Global, el::ConfigurationType::Filename, fileName);
+		el::Loggers::reconfigureLogger("Client", s_clientConfig);
+	}
+
+	void Log::setCoreLogFile(const std::string& fileName)
+	{
+		s_coreConfig.set(el::Level::Global, el::ConfigurationType::ToFile, "true");
+		s_coreConfig.set(el::Level::Global, el::ConfigurationType::Filename, fileName);
+		el::Loggers::reconfigureLogger("Core", s_coreConfig);
+	}
+
+	void Log::setLogLevel(LogLevel newLevel)
+	{
+		s_coreConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+		s_clientConfig.set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+
+		// We don't use these levels so they are always disabled
+		s_coreConfig.set(el::Level::Debug, el::ConfigurationType::Enabled, "false");
+		s_coreConfig.set(el::Level::Verbose, el::ConfigurationType::Enabled, "false");
+		s_clientConfig.set(el::Level::Debug, el::ConfigurationType::Enabled, "false");
+		s_clientConfig.set(el::Level::Verbose, el::ConfigurationType::Enabled, "false");
+
+		if (newLevel > LogLevel::Trace)
+		{
+			s_coreConfig.set(el::Level::Trace, el::ConfigurationType::Enabled, "false");
+			s_clientConfig.set(el::Level::Trace, el::ConfigurationType::Enabled, "false");
+		}
+
+		if (newLevel > LogLevel::Info)
+		{
+			s_coreConfig.set(el::Level::Info, el::ConfigurationType::Enabled, "false");
+			s_clientConfig.set(el::Level::Info, el::ConfigurationType::Enabled, "false");
+		}
+
+		if (newLevel > LogLevel::Warning)
+		{
+			s_coreConfig.set(el::Level::Warning, el::ConfigurationType::Enabled, "false");
+			s_clientConfig.set(el::Level::Warning, el::ConfigurationType::Enabled, "false");
+		}
+
+		if (newLevel > LogLevel::Error)
+		{
+			s_coreConfig.set(el::Level::Error, el::ConfigurationType::Enabled, "false");
+			s_clientConfig.set(el::Level::Error, el::ConfigurationType::Enabled, "false");
+		}
+
+		if (newLevel > LogLevel::Fatal)
+		{
+			s_coreConfig.set(el::Level::Fatal, el::ConfigurationType::Enabled, "false");
+			s_clientConfig.set(el::Level::Fatal, el::ConfigurationType::Enabled, "false");
+		}
+
+		el::Loggers::reconfigureLogger("Client", s_clientConfig);
+		el::Loggers::reconfigureLogger("Core", s_coreConfig);
+	}
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Log.h
+++ b/Aquarius/Src/Aquarius/Core/Log.h
@@ -21,6 +21,16 @@
 
 namespace Aquarius {
 
+	enum class LogLevel
+	{
+		All = 0,
+		Trace,
+		Info,
+		Warning,
+		Error,
+		Fatal,
+		Disabled
+	};
 	class Log
 	{
 	public:
@@ -28,10 +38,17 @@ namespace Aquarius {
 
 		static el::Logger* getClientLogger() { return s_clientLogger; }
 		static el::Logger* getCoreLogger() { return s_coreLogger; }
+
+		static void setClientLogFile(const std::string& fileName);
+		static void setCoreLogFile(const std::string& fileName);
+
+		static void setLogLevel(LogLevel level);
 	private:
 		Log() = delete;
 
 		static el::Logger* s_clientLogger;
 		static el::Logger* s_coreLogger;
+		static el::Configurations s_clientConfig;
+		static el::Configurations s_coreConfig;
 	};
 } // namespace Aquarius


### PR DESCRIPTION
This PR adds the ability to set the logging level, the logging levels are defined as follows (from least to greatest severity):
```
Trace
Info
Warning
Error
Fatal
```
Note: Fatal logs cause the program to terminate

The ability to set a logging output file for both the core and client loggers is now possible, with the default being that the loggers do not log their output to a file, but just the console.

P.S. base branch is set to assertion-wrapper just so those changes don't show up in the diff (I rebased on top of it)