### PR TITLE
Core application class and entry point abstraction

### DIFF
--- a/Aquarius/Src/Aquarius/Core/Application.cpp
+++ b/Aquarius/Src/Aquarius/Core/Application.cpp
@@ -4,20 +4,20 @@
 
 namespace Aquarius {
 
-	Application* Application::s_application = nullptr;
+	Application* Application::s_Application = nullptr;
 
-	Application* Application::get() { return s_application; }
+	Application* Application::get() { return s_Application; }
 
-	Window* Application::getWindow() { return m_window.get(); }
+	Window* Application::getWindow() { return m_Window.get(); }
 
 	Application::Application(std::string&& windowName)
-		: m_window(Window::Create(800, 600, std::move(windowName)))
+		: m_Window(Window::Create(800, 600, std::move(windowName)))
 	{
-		s_application = this;
+		s_Application = this;
 
 		Log::initLoggers();
 
-		m_window->Initialize();
+		m_Window->Initialize();
 
 		AQ_CORE_INFO("Window Initialized Sucessfully");
 	}
@@ -28,7 +28,7 @@ namespace Aquarius {
 		{
 			glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 			glClear(GL_COLOR_BUFFER_BIT);
-			m_window->OnUpdate();
+			m_Window->OnUpdate();
 		}
 	}
 

--- a/Aquarius/Src/Aquarius/Core/Application.cpp
+++ b/Aquarius/Src/Aquarius/Core/Application.cpp
@@ -1,0 +1,46 @@
+
+#include "Application.h"
+#include "Aquarius/Core/Log.h"
+
+namespace Aquarius {
+
+	Application* Application::s_application = nullptr;
+
+	Application* Application::get() { return s_application; }
+
+	Window* Application::getWindow() { return m_window.get(); }
+
+	Application::Application(std::string&& windowName)
+		: m_window(Window::Create(800, 600, std::move(windowName)))
+	{
+		s_application = this;
+
+		Log::initLoggers();
+
+		m_window->Initialize();
+
+		AQ_CORE_INFO("Window Initialized Sucessfully");
+	}
+
+	void Application::run()
+	{
+		while (true)
+		{
+			glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+			glClear(GL_COLOR_BUFFER_BIT);
+			m_window->OnUpdate();
+		}
+	}
+
+} // namespace Aquarius
+
+extern Aquarius::Application::ApplicationPtr createApplication();
+
+int main(int argc, char* argv[])
+{
+	auto application = createApplication();
+
+	application->run();
+
+	return 0;
+}

--- a/Aquarius/Src/Aquarius/Core/Application.h
+++ b/Aquarius/Src/Aquarius/Core/Application.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Aquarius/Core/Window.h"
+
+#include <memory>
+
+namespace Aquarius {
+
+	class Application
+	{
+	public:
+		Application() = delete;
+		Application(const Application&) = delete;
+
+		using ApplicationPtr = std::unique_ptr<Application>;
+
+		virtual ~Application() {};
+
+		static Application* get();
+
+		Window* getWindow();
+
+		void run();
+	protected:
+		Application(std::string&& windowName = "Application");
+	private:
+		static Application* s_application;
+		Window::WindowPtr m_window;
+	};
+
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Application.h
+++ b/Aquarius/Src/Aquarius/Core/Application.h
@@ -9,10 +9,10 @@ namespace Aquarius {
 	class Application
 	{
 	public:
+		using ApplicationPtr = std::unique_ptr<Application>;
+
 		Application() = delete;
 		Application(const Application&) = delete;
-
-		using ApplicationPtr = std::unique_ptr<Application>;
 
 		virtual ~Application() {};
 
@@ -24,8 +24,8 @@ namespace Aquarius {
 	protected:
 		Application(std::string&& windowName = "Application");
 	private:
-		static Application* s_application;
-		Window::WindowPtr m_window;
+		static Application* s_Application;
+		Window::WindowPtr m_Window;
 	};
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -9,9 +9,9 @@ namespace Aquarius {
     // GLFW Window
     class Window
     {
+    public:
         using WindowPtr = std::unique_ptr<Window>;
 
-    public:
         // Creation
         Window(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);
         static WindowPtr Create(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);

--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Sandbox)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(sources Sandbox.cpp)
+file(GLOB_RECURSE sources *.h *.cpp)
 
 add_executable(Sandbox ${sources})
 

--- a/Sandbox/Sandbox.cpp
+++ b/Sandbox/Sandbox.cpp
@@ -1,9 +1,7 @@
+#include "Sandbox.h"
+
 #include <Aquarius.h>
 
-int main()
-{
-    Aquarius::Test test;
-    test.testMain();
-
-    return 0;
-}
+Sandbox::Sandbox()
+	: Aquarius::Application("Sandbox")
+{}

--- a/Sandbox/Sandbox.cpp
+++ b/Sandbox/Sandbox.cpp
@@ -5,3 +5,8 @@
 Sandbox::Sandbox()
 	: Aquarius::Application("Sandbox")
 {}
+
+Aquarius::Application::ApplicationPtr createApplication()
+{
+	return std::make_unique<Sandbox>();
+}

--- a/Sandbox/Sandbox.h
+++ b/Sandbox/Sandbox.h
@@ -8,7 +8,4 @@ public:
 	Sandbox();
 };
 
-Aquarius::Application::ApplicationPtr createApplication()
-{
-	return std::make_unique<Sandbox>();
-}
+Aquarius::Application::ApplicationPtr createApplication();

--- a/Sandbox/Sandbox.h
+++ b/Sandbox/Sandbox.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Aquarius/Core/Application.h"
+
+class Sandbox : public Aquarius::Application
+{
+public:
+	Sandbox();
+};
+
+Aquarius::Application::ApplicationPtr createApplication()
+{
+	return std::make_unique<Sandbox>();
+}


### PR DESCRIPTION
This PR adds a base Application class that we can build off of. It also changes the Sandbox example to utilize this new Application class.

To use, a derived class must be created with a constructor that calls the base constructor (passing a std::string for the window name). As well, a createApplication function which returns a `std::unique_ptr<Application>` must be created, returning a derived unique_ptr invoking the constructor.