### PR TITLE
Add Vertex/Index Buffer Abstractions

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -4,6 +4,8 @@
 #include "Aquarius/Core/Log.h"
 #include "Aquarius/Core/Window.h"
 #include "Aquarius/Core/Assert.h"
+#include "Aquarius/Renderer/VertexBuffer.h"
+#include "Aquarius/Renderer/IndexBuffer.h"
 
 
 namespace Aquarius {
@@ -28,5 +30,58 @@ namespace Aquarius {
         return 0;
     }
 
+    int Test::triangleTest()
+    {
+        // Init logging
+        Log::initLoggers();
+
+        // Create Window
+        std::unique_ptr<Window> Window = Window::Create(800, 600, "Aquarius");
+        Window->Initialize();
+
+        // Single Triangle Vertices (NDC - Just Pos)
+        std::vector<float> data =
+        {
+                // position
+              -0.5f, 0.0f, 0.0f,
+               0.0f, 0.5f, 0.0f,
+               0.5f, 0.0f, 0.0f,
+               0.0f, -0.5f, 0.0f
+        };
+
+        // Rectangle Indices
+        std::vector<uint32_t> indices =
+        {
+            0, 1, 2,    // Triangle 1
+            0, 2, 3     // Triangle 2
+        };
+
+        // TODO - Create vertex array abstraction
+        uint32_t VA0;
+        glGenVertexArrays(1, &VA0);
+        glBindVertexArray(VA0);
+
+        // Create and bind vertex buffer
+        VertexBuffer VB0 = VertexBuffer(data.data(), data.size() * sizeof(data[0]));
+        VB0.Bind();
+
+        // Create and bind index buffer
+        IndexBuffer IB0 = IndexBuffer(indices.data(), indices.size());
+        IB0.Bind();
+
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+        glEnableVertexAttribArray(0);
+
+        // Render loop
+        while (1)
+        {
+            glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glDrawElements(GL_TRIANGLES, 2, GL_UNSIGNED_INT, 0);
+            Window->OnUpdate();
+        }
+
+        return 0;
+    }
 } // namespace Aquarius
 

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -12,5 +12,6 @@ namespace Aquarius {
     {
     public:
         int testMain();
+        int triangleTest();
     };
 }

--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.cpp
@@ -3,12 +3,20 @@
 
 namespace Aquarius {
 
-    IndexBuffer::IndexBuffer(uint32_t *data, size_t count)
+    IndexBuffer::IndexBuffer(uint32_t* data, size_t count)
         : m_Count(count)
     {
         glGenBuffers(1, &m_ID);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ID);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), data, GL_STATIC_DRAW);
+    }
+
+    IndexBuffer::IndexBuffer(uint16_t* data, size_t count)
+            : m_Count(count)
+    {
+        glGenBuffers(1, &m_ID);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ID);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint16_t), data, GL_STATIC_DRAW);
     }
 
     IndexBuffer::~IndexBuffer()

--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.cpp
@@ -1,0 +1,33 @@
+#include "IndexBuffer.h"
+#include <glad/glad.h>
+
+namespace Aquarius {
+
+    IndexBuffer::IndexBuffer(uint32_t *data, size_t count)
+        : m_Count(count)
+    {
+        glGenBuffers(1, &m_ID);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ID);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), data, GL_STATIC_DRAW);
+    }
+
+    IndexBuffer::~IndexBuffer()
+    {
+        glDeleteBuffers(1, &m_ID);
+    }
+
+    void IndexBuffer::Bind() const
+    {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ID);
+    }
+
+    void IndexBuffer::Unbind() const
+    {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    }
+
+    size_t IndexBuffer::getCount()
+    {
+        return m_Count;
+    }
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+namespace Aquarius {
+
+    class IndexBuffer
+    {
+    public:
+        IndexBuffer(uint32_t* data, size_t count);
+        ~IndexBuffer();
+
+        void Bind() const;
+        void Unbind() const;
+        size_t getCount();
+
+    private:
+        uint32_t m_ID;
+        size_t m_Count;
+    };
+}

--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
@@ -7,6 +7,7 @@ namespace Aquarius {
     {
     public:
         IndexBuffer(uint32_t* data, size_t count);
+        IndexBuffer(uint16_t* data, size_t count);
         ~IndexBuffer();
 
         void Bind() const;

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.cpp
@@ -3,7 +3,14 @@
 
 namespace Aquarius {
 
-    VertexBuffer::VertexBuffer(void *data, size_t size)
+    VertexBuffer::VertexBuffer(float* data, size_t size)
+    {
+        glGenBuffers(1, &m_ID);
+        glBindBuffer(GL_ARRAY_BUFFER, m_ID);
+        glBufferData(GL_ARRAY_BUFFER, size, data, GL_STATIC_DRAW);
+    }
+
+    VertexBuffer::VertexBuffer(double* data, size_t size)
     {
         glGenBuffers(1, &m_ID);
         glBindBuffer(GL_ARRAY_BUFFER, m_ID);

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.cpp
@@ -1,0 +1,27 @@
+#include "VertexBuffer.h"
+#include <glad/glad.h>
+
+namespace Aquarius {
+
+    VertexBuffer::VertexBuffer(void *data, size_t size)
+    {
+        glGenBuffers(1, &m_ID);
+        glBindBuffer(GL_ARRAY_BUFFER, m_ID);
+        glBufferData(GL_ARRAY_BUFFER, size, data, GL_STATIC_DRAW);
+    }
+
+    VertexBuffer::~VertexBuffer()
+    {
+        glDeleteBuffers(1, &m_ID);
+    }
+
+    void VertexBuffer::Bind() const
+    {
+        glBindBuffer(GL_ARRAY_BUFFER, m_ID);
+    }
+
+    void VertexBuffer::Unbind() const
+    {
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstdint>
+
+namespace Aquarius {
+
+    class VertexBuffer
+    {
+    public:
+        VertexBuffer(void* data, size_t size);
+        ~VertexBuffer();
+
+        void Bind() const;
+        void Unbind() const;
+
+    private:
+        uint32_t m_ID;
+    };
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
@@ -6,7 +6,8 @@ namespace Aquarius {
     class VertexBuffer
     {
     public:
-        VertexBuffer(void* data, size_t size);
+        VertexBuffer(float* data, size_t size);
+        VertexBuffer(double* data, size_t size);
         ~VertexBuffer();
 
         void Bind() const;


### PR DESCRIPTION
## Brief
This PR adds simple abstraction around OpenGL vertex and index buffer.

## Summary
- `VertexBuffer`: Create, bind, destroy vertex buffer given a pointer to some data 
- `IndexBuffer`: Create, bind, destroy vertex buffer given a pointer to a uint32_t array of indices

## Note
I cant test / render any thing until I add shader abstraction, so I may actually do that before I do VertexArray abstraction.