### PR TITLE
Fix size_t error on Clang

### DIFF
--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <stddef.h>
 
 namespace Aquarius {
 

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <stddef.h>
 
 namespace Aquarius {
 


### PR DESCRIPTION
-Added #include <stddef.h> into IndexBuffer.h and VertexBuffer.h to resolve size_t error being returned by clang.