### PR TITLE
Cleanup and Add Utilities

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -1,11 +1,6 @@
 #define AQ_ASSERT_ENABLE
 
 #include "Aquarius.h"
-#include "Aquarius/Core/Log.h"
-#include "Aquarius/Core/Window.h"
-#include "Aquarius/Core/Assert.h"
-#include "Aquarius/Renderer/VertexBuffer.h"
-#include "Aquarius/Renderer/IndexBuffer.h"
 
 
 namespace Aquarius {

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -1,11 +1,3 @@
-
-#include <iostream>
-#include <glad/glad.h>
-#include <GLFW/glfw3.h>
-#include <easylogging++.h>
-#include <stb_image.h>
-#include <glm/glm.hpp>
-
 // -- Core
 #include "Aquarius/Core/Utility.h"
 #include "Aquarius/Core/Application.h"
@@ -22,6 +14,14 @@
 #include "Aquarius/Events/Keyboard.h"
 #include "Aquarius/Events/Mouse.h"
 #include "Aquarius/Events/Window.h"
+
+#include <iostream>
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+#include <easylogging++.h>
+#include <stb_image.h>
+#include <glm/glm.hpp>
+
 
 namespace Aquarius {
     class Test

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -6,6 +6,22 @@
 #include <stb_image.h>
 #include <glm/glm.hpp>
 
+// -- Core
+#include "Aquarius/Core/Utility.h"
+#include "Aquarius/Core/Application.h"
+#include "Aquarius/Core/Assert.h"
+#include "Aquarius/Core/Input.h"
+#include "Aquarius/Core/Log.h"
+#include "Aquarius/Core/Window.h"
+
+// -- Renderer
+#include "Aquarius/Renderer/IndexBuffer.h"
+#include "Aquarius/Renderer/VertexBuffer.h"
+
+// -- Events
+#include "Aquarius/Events/Keyboard.h"
+#include "Aquarius/Events/Mouse.h"
+#include "Aquarius/Events/Window.h"
 
 namespace Aquarius {
     class Test

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -15,12 +15,12 @@
 #include "Aquarius/Events/Mouse.h"
 #include "Aquarius/Events/Window.h"
 
-#include <iostream>
+#include <easylogging++.h>
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
-#include <easylogging++.h>
-#include <stb_image.h>
 #include <glm/glm.hpp>
+#include <iostream>
+#include <stb_image.h>
 
 
 namespace Aquarius {

--- a/Aquarius/CMakeLists.txt
+++ b/Aquarius/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Aquarius-Engine)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+add_definitions(-DGLFW_INCLUDE_NONE)
 
 file(GLOB_RECURSE Sources "Src/*.cpp" "Src/*.h")
 

--- a/Aquarius/Src/Aquarius/Core/Application.cpp
+++ b/Aquarius/Src/Aquarius/Core/Application.cpp
@@ -1,7 +1,7 @@
-
 #include "Application.h"
-#include "Aquarius/Core/Log.h"
 #include "Aquarius/Core/Input.h"
+#include "Aquarius/Core/Log.h"
+
 
 namespace Aquarius {
 
@@ -35,7 +35,7 @@ namespace Aquarius {
 
 } // namespace Aquarius
 
-extern Aquarius::Application::ApplicationPtr createApplication();
+extern Aquarius::uniquePtr<Aquarius::Application> createApplication();
 
 int main(int argc, char* argv[])
 {

--- a/Aquarius/Src/Aquarius/Core/Application.h
+++ b/Aquarius/Src/Aquarius/Core/Application.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "Aquarius/Core/Window.h"
+#include "Aquarius/Core/Utility.h"
 
 #include <memory>
+
 
 namespace Aquarius {
 
@@ -25,7 +27,7 @@ namespace Aquarius {
 		Application(std::string&& windowName = "Application");
 	private:
 		static Application* s_Application;
-		Window::WindowPtr m_Window;
+		uniquePtr<Window> m_Window;
 	};
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Application.h
+++ b/Aquarius/Src/Aquarius/Core/Application.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Aquarius/Core/Window.h"
 #include "Aquarius/Core/Utility.h"
+#include "Aquarius/Core/Window.h"
 
 #include <memory>
 

--- a/Aquarius/Src/Aquarius/Core/Assert.h
+++ b/Aquarius/Src/Aquarius/Core/Assert.h
@@ -4,53 +4,55 @@
 
 #include <string>
 
+
 namespace Aquarius {
 
-inline void aqCoreAssert(bool expression)
-{
-	#ifdef AQ_ASSERT_ENABLE
-	if (!expression)
-	{
-		AQ_CORE_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
-		std::abort();
-	}
-	#endif
-}
+    inline void aqCoreAssert(bool expression)
+    {
+        #ifdef AQ_ASSERT_ENABLE
+        if (!expression)
+        {
+            AQ_CORE_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
+            std::abort();
+        }
+        #endif
+    }
 
-template<typename Msg, typename ... Ts>
-inline void aqCoreAssert(bool expression, Msg message, Ts ... args)
-{
-	#ifdef AQ_ASSERT_ENABLE
-	if (!expression)
-	{
-		std::string errorMessage = "Assertion failed: " + std::string(message);
-		AQ_CORE_ERROR(errorMessage.c_str(), args...);
-		std::abort();
-	}
-	#endif
-}
+    template<typename Msg, typename ... Ts>
+    inline void aqCoreAssert(bool expression, Msg message, Ts ... args)
+    {
+        #ifdef AQ_ASSERT_ENABLE
+        if (!expression)
+        {
+            std::string errorMessage = "Assertion failed: " + std::string(message);
+            AQ_CORE_ERROR(errorMessage.c_str(), args...);
+            std::abort();
+        }
+        #endif
+    }
 
-inline void aqAssert(bool expression)
-{
-	#ifdef AQ_ASSERT_ENABLE
-	if (!expression)
-	{
-		AQ_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
-		std::abort();
-	}
-	#endif
-}
+    inline void aqAssert(bool expression)
+    {
+        #ifdef AQ_ASSERT_ENABLE
+        if (!expression)
+        {
+            AQ_ERROR("Assertion failed at %v:%v", __FILE__, __LINE__);
+            std::abort();
+        }
+        #endif
+    }
 
-template<typename Msg, typename ... Ts>
-inline void aqAssert(bool expression, Msg message, Ts ... args)
-{
-	#ifdef AQ_ASSERT_ENABLE
-	if (!expression)
-	{
-		std::string errorMessage = "Assertion failed: " + std::string(message);
-		AQ_ERROR(errorMessage.c_str(), args...);
-		std::abort();
-	}
-	#endif
-}
+    template<typename Msg, typename ... Ts>
+    inline void aqAssert(bool expression, Msg message, Ts ... args)
+    {
+        #ifdef AQ_ASSERT_ENABLE
+        if (!expression)
+        {
+            std::string errorMessage = "Assertion failed: " + std::string(message);
+            AQ_ERROR(errorMessage.c_str(), args...);
+            std::abort();
+        }
+        #endif
+    }
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Input.cpp
+++ b/Aquarius/Src/Aquarius/Core/Input.cpp
@@ -1,5 +1,5 @@
 #include "Input.h"
-#include "Application.h"
+#include "Aquarius/Core/Application.h"
 
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Core/Input.cpp
+++ b/Aquarius/Src/Aquarius/Core/Input.cpp
@@ -1,10 +1,9 @@
 #include "Input.h"
-
 #include "Application.h"
 
-#include <GLFW/glfw3.h>
 
 namespace Aquarius {
+
 	namespace Input {
 
 		KeyState getKeyState(KeyCode key)
@@ -37,5 +36,7 @@ namespace Aquarius {
 
 			return position;
 		}
+
 	} // namespace Input
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Input.h
+++ b/Aquarius/Src/Aquarius/Core/Input.h
@@ -1,10 +1,11 @@
-#include <cstdint>
-
 #include "Window.h"
 
-namespace Aquarius {
-	namespace Input {
+#include <cstdint>
 
+
+namespace Aquarius {
+
+	namespace Input {
 
 		enum class KeyState : int
 		{
@@ -167,5 +168,7 @@ namespace Aquarius {
 		bool isKeyPressed(KeyCode key);
 		bool isMouseButtonPressed(MouseButtonCode button);
 		MousePosition getMousePosition();
+
 	} // namespace Input
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Input.h
+++ b/Aquarius/Src/Aquarius/Core/Input.h
@@ -1,4 +1,4 @@
-#include "Window.h"
+#include "Aquarius/Core/Window.h"
 
 #include <cstdint>
 

--- a/Aquarius/Src/Aquarius/Core/Log.cpp
+++ b/Aquarius/Src/Aquarius/Core/Log.cpp
@@ -1,5 +1,6 @@
 #include "Log.h"
 
+
 INITIALIZE_EASYLOGGINGPP
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Core/Log.h
+++ b/Aquarius/Src/Aquarius/Core/Log.h
@@ -2,6 +2,7 @@
 
 #include "easylogging++.h"
 
+
 // Note: for printf-like formatting, use only %v instead of type specific identifiers within log string
 
 // Core log macros
@@ -51,4 +52,5 @@ namespace Aquarius {
 		static el::Configurations s_clientConfig;
 		static el::Configurations s_coreConfig;
 	};
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Utility.h
+++ b/Aquarius/Src/Aquarius/Core/Utility.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+
 namespace Aquarius {
 
     template<typename T>

--- a/Aquarius/Src/Aquarius/Core/Utility.h
+++ b/Aquarius/Src/Aquarius/Core/Utility.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <memory>
+
+namespace Aquarius {
+
+    template<typename T>
+    using uniquePtr = std::unique_ptr<T>;
+
+    template<typename T>
+    using sharedPtr = std::shared_ptr<T>;
+
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -16,7 +16,7 @@ namespace Aquarius {
           m_Context(nullptr)
     {}
 
-    Window::WindowPtr Window::Create(uint32_t width, uint32_t height, std::string &&name, bool vsync)
+    uniquePtr<Window> Window::Create(uint32_t width, uint32_t height, std::string &&name, bool vsync)
     {
         return std::make_unique<Window>(width, height, std::move(name));
     }

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -1,8 +1,8 @@
 #include "Window.h"
-#include "Log.h"
-#include "Aquarius/Events/Keyboard.h"
-#include "Aquarius/Events/Mouse.h"
 #include "Aquarius/Core/Input.h"
+#include "Aquarius/Events/Keyboard.h"
+#include "Aquarius/Core/Log.h"
+#include "Aquarius/Events/Mouse.h"
 
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -1,9 +1,9 @@
 #include "Window.h"
 #include "Log.h"
-#include <assert.h>
 #include "Aquarius/Events/Keyboard.h"
 #include "Aquarius/Events/Mouse.h"
 #include "Aquarius/Core/Input.h"
+
 
 namespace Aquarius {
 

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "Aquarius/Renderer/RenderingContext.h"
 #include "Aquarius/Core/Utility.h"
+#include "Aquarius/Renderer/RenderingContext.h"
 
-#include <string>
 #include <memory>
 #include <GLFW/glfw3.h>
+#include <string>
 
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -1,20 +1,21 @@
 #pragma once
+
+#include "Aquarius/Renderer/RenderingContext.h"
+#include "Aquarius/Core/Utility.h"
+
 #include <string>
 #include <memory>
-#include <Aquarius/Renderer/RenderingContext.h>
 #include <GLFW/glfw3.h>
+
 
 namespace Aquarius {
 
-    // GLFW Window
     class Window
     {
     public:
-        using WindowPtr = std::unique_ptr<Window>;
-
         // Creation
         Window(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);
-        static WindowPtr Create(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);
+        static uniquePtr<Window> Create(uint32_t width, uint32_t height, std::string&& name, bool vsync = false);
 
         // Initialize GLFW
         void Initialize();

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -46,4 +46,5 @@ namespace Aquarius {
         // Deallocate window resources
         void Deallocate();
     };
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Events/Keyboard.h
+++ b/Aquarius/Src/Aquarius/Events/Keyboard.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <GLFW/glfw3.h>
-
 #include "Aquarius/Core/Log.h"
+
+#include <GLFW/glfw3.h>
 
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Events/Keyboard.h
+++ b/Aquarius/Src/Aquarius/Events/Keyboard.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <GLFW/glfw3.h>
+
 #include "Aquarius/Core/Log.h"
+
 
 namespace Aquarius {
 
@@ -31,4 +33,5 @@ namespace Aquarius {
             }
         }
     };
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Events/Mouse.h
+++ b/Aquarius/Src/Aquarius/Events/Mouse.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <GLFW/glfw3.h>
 #include "Aquarius/Core/Log.h"
+
+#include <GLFW/glfw3.h>
+
 
 namespace Aquarius {
 
@@ -54,4 +56,5 @@ namespace Aquarius {
             AQ_INFO("y offset: %v", yOffset);
         }
     };
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Events/Window.h
+++ b/Aquarius/Src/Aquarius/Events/Window.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include <GLFW/glfw3.h>
 #include "Aquarius/Core/Log.h"
+
+#include <GLFW/glfw3.h>
+
 
 namespace Aquarius {
 
     class WindowEvent
-            {
+    {
     public:
 
         static void windowCloseCallback(GLFWwindow* window)
@@ -54,4 +56,5 @@ namespace Aquarius {
             //TODO Implement
         }
     };
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.cpp
@@ -1,5 +1,7 @@
 #include "IndexBuffer.h"
+
 #include <glad/glad.h>
+
 
 namespace Aquarius {
 
@@ -38,4 +40,5 @@ namespace Aquarius {
     {
         return m_Count;
     }
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/IndexBuffer.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <cstdint>
 #include <stddef.h>
+
 
 namespace Aquarius {
 
@@ -19,4 +21,5 @@ namespace Aquarius {
         uint32_t m_ID;
         size_t m_Count;
     };
-}
+
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -1,5 +1,5 @@
 #include "RenderingContext.h"
-#include <Aquarius/Core/Log.h>
+#include "Aquarius/Core/Log.h"
 
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -35,5 +35,5 @@ namespace Aquarius {
     {
         glfwSwapBuffers(m_Window);
     }
-    
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -35,4 +35,5 @@ namespace Aquarius {
     {
         glfwSwapBuffers(m_Window);
     }
+    
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.cpp
@@ -8,7 +8,7 @@ namespace Aquarius {
     :   m_Window(window)
     {}
 
-    RenderingContext::ContextPtr RenderingContext::Create(GLFWwindow *window)
+    uniquePtr<RenderingContext> RenderingContext::Create(GLFWwindow *window)
     {
         return std::make_unique<RenderingContext>(window);
     }

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
@@ -1,17 +1,20 @@
 #pragma once
+
+#include "Aquarius/Core/Utility.h"
+
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <memory>
+
 
 namespace Aquarius {
 
     // OpenGL Rendering Context
     class RenderingContext
     {
-        using ContextPtr = std::unique_ptr<RenderingContext>;
     public:
         RenderingContext(GLFWwindow* window);
-        static ContextPtr Create(GLFWwindow* window);
+        static uniquePtr<RenderingContext> Create(GLFWwindow* window);
 
         void Initialize();
         void SwapBuffers();

--- a/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
+++ b/Aquarius/Src/Aquarius/Renderer/RenderingContext.h
@@ -22,4 +22,5 @@ namespace Aquarius {
     private:
         GLFWwindow* m_Window;
     };
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/Shader.h
+++ b/Aquarius/Src/Aquarius/Renderer/Shader.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <iostream>
 #include <glm/glm.hpp>
+#include <iostream>
 #include <unordered_map>
 
 

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.cpp
@@ -1,5 +1,7 @@
 #include "VertexBuffer.h"
+
 #include <glad/glad.h>
+
 
 namespace Aquarius {
 
@@ -31,4 +33,5 @@ namespace Aquarius {
     {
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexBuffer.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <cstdint>
 #include <stddef.h>
 
@@ -17,4 +18,5 @@ namespace Aquarius {
     private:
         uint32_t m_ID;
     };
+
 } // namespace Aquarius

--- a/Sandbox/CMakeLists.txt
+++ b/Sandbox/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Sandbox)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+add_definitions(-DGLFW_INCLUDE_NONE)
 
 file(GLOB_RECURSE sources *.h *.cpp)
 

--- a/Sandbox/Sandbox.cpp
+++ b/Sandbox/Sandbox.cpp
@@ -6,7 +6,7 @@ Sandbox::Sandbox()
 	: Aquarius::Application("Sandbox")
 {}
 
-Aquarius::Application::ApplicationPtr createApplication()
+Aquarius::uniquePtr<Aquarius::Application> createApplication()
 {
 	return std::make_unique<Sandbox>();
 }

--- a/Sandbox/Sandbox.cpp
+++ b/Sandbox/Sandbox.cpp
@@ -1,6 +1,5 @@
 #include "Sandbox.h"
 
-#include <Aquarius.h>
 
 Sandbox::Sandbox()
 	: Aquarius::Application("Sandbox")

--- a/Sandbox/Sandbox.h
+++ b/Sandbox/Sandbox.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Aquarius/Core/Application.h"
+#include <Aquarius.h>
 
 class Sandbox : public Aquarius::Application
 {


### PR DESCRIPTION
This is a PR that looks like a big diff but it's not, it just touches a lot of files with spacing changes. I added a similar wrapping of unique and shared pointer as The Chernos Ref and Scope, without the fancy wrapping of std::make_unique and shared with variatic arguments (I'm thinking we can just use std::make_unique when we have to).

Apart from that, I updated the includes with new spacing and ordering, and discovered some unsused includes I could remove. I also added a definition to the Aquarius and Sandbox cmakelists to avoid dumb `glad already included` errors (and tested) .

Finally, I included all of the engine headers in Aquarius.h so clients can just include one file and get all of the engine stuff (usually this would be a precompiled header).

If anything I did makes no sense, LMK! :) 

P.S. 
Instead of looking at the diff in one file view, this one might be better viewed as a side by side diff due to all the whitespace changes. 