### PR TITLE
Vertex Array Object Abstraction

### DIFF
--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -41,14 +41,14 @@ namespace Aquarius {
         // Bind shader
         shaderProgram.activate();
 
-        // Single Triangle Vertices (NDC - Just Pos)
+        // Single Triangle Vertices (NDC)
         std::vector<float> data =
         {
-                // position
-              -0.5f, 0.0f,
-               0.0f, 0.5f,
-               0.5f, 0.0f,
-               0.0f, -0.5f
+                // Position     // Color
+              -0.5f, 0.0f,      0.5f, 0.5f, 0.5f,
+               0.0f, 0.5f,      0.5f, 0.5f, 0.5f,
+               0.5f, 0.0f,      0.5f, 0.5f, 0.5f,
+               0.0f, -0.5f,     0.5f, 0.5f, 0.5f,
         };
 
         // Rectangle Indices
@@ -58,33 +58,27 @@ namespace Aquarius {
             0, 2, 3     // Triangle 2
         };
 
-        // TODO - Create vertex array abstraction
-        uint32_t VA0;
-        glGenVertexArrays(1, &VA0);
-        glBindVertexArray(VA0);
+        auto VB0 = std::make_shared<VertexBuffer>(data.data(), data.size() * sizeof(float));
+        auto IB0 = std::make_shared<IndexBuffer>(indices.data(), indices.size());
+        auto layout = BufferLayout(
+        {
+                VertexElement(ShaderType::Float, 2, false),
+                VertexElement(ShaderType::Float, 3, false)
+        });
 
-        // Create and bind vertex buffer
-        VertexBuffer VB0 = VertexBuffer(data.data(), data.size() * sizeof(float));
-        VB0.Bind();
-
-        // Create and bind index buffer
-        IndexBuffer IB0 = IndexBuffer(indices.data(), indices.size());
-        IB0.Bind();
-
-        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
-        glEnableVertexAttribArray(0);
+        auto VA0 = VertexArray(VB0, IB0, layout);
+        VA0.activate();
 
         // Render loop
         while (1)
         {
             glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
             glClear(GL_COLOR_BUFFER_BIT);
-            shaderProgram.setFloat4("color", {1.0f, 1.0f, 1.0f, 1.0f});
             glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, (void*)0);
             Window->OnUpdate();
         }
 
         return 0;
     }
-} // namespace Aquarius
 
+} // namespace Aquarius

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -9,6 +9,8 @@
 // -- Renderer
 #include "Aquarius/Renderer/IndexBuffer.h"
 #include "Aquarius/Renderer/VertexBuffer.h"
+#include "Aquarius/Renderer/VertexArray.h"
+#include "Aquarius/Renderer/Shader.h"
 
 // -- Events
 #include "Aquarius/Events/Keyboard.h"

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -5,7 +5,6 @@
 
 namespace Aquarius {
 
-    // TODO - What style to use here
     VertexArray::VertexArray(const std::shared_ptr<VertexBuffer>& vertexBuffer,
                              const std::shared_ptr<IndexBuffer>& indexBuffer,
                              const BufferLayout& bufferLayout)
@@ -13,8 +12,7 @@ namespace Aquarius {
     {
         glGenVertexArrays(1, &m_ID);
         setIndexBuffer(indexBuffer);
-        setVertexBuffer(vertexBuffer);
-        setBufferLayout(bufferLayout);
+        setVertexBuffer(vertexBuffer, bufferLayout);
     }
 
     VertexArray::VertexArray()
@@ -37,32 +35,40 @@ namespace Aquarius {
         glBindVertexArray(0);
     }
 
+    void VertexArray::setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer, const BufferLayout& bufferLayout)
+    {
+        activate();
+        vertexBuffer->Bind();
+        m_VertexBuffer = vertexBuffer;
+        setBufferLayout(bufferLayout);
+    }
+
     void VertexArray::setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer)
     {
-        m_VertexBuffer = vertexBuffer;
         activate();
-        m_VertexBuffer->Bind();
+        vertexBuffer->Bind();
+        m_VertexBuffer = vertexBuffer;
     }
 
     void VertexArray::setIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)
     {
-        m_IndexBuffer = indexBuffer;
         activate();
-        m_IndexBuffer->Bind();
+        indexBuffer->Bind();
+        m_IndexBuffer = indexBuffer;
     }
 
     void VertexArray::setBufferLayout(const BufferLayout& bufferLayout)
     {
         activate();
 
-        size_t vertexAttribIndex = 0;
+        uint32_t vertexAttribIndex = 0;
         for (auto elem : bufferLayout.getElements())
         {
             glEnableVertexAttribArray(vertexAttribIndex);
             glVertexAttribPointer(vertexAttribIndex,
                                   elem.getCount(),
                                   elem.getType(),
-                                  elem.getNormalize(),
+                                  elem.getNormalize() ? GL_TRUE : GL_FALSE,
                                   bufferLayout.getStride(),
                                   (void*)elem.getOffset());
             vertexAttribIndex++;

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -62,7 +62,7 @@ namespace Aquarius {
         activate();
 
         uint32_t vertexAttribIndex = 0;
-        for (auto elem : bufferLayout.getElements())
+        for (const auto& elem : bufferLayout.getElements())
         {
             glEnableVertexAttribArray(vertexAttribIndex);
             glVertexAttribPointer(vertexAttribIndex,

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -1,0 +1,14 @@
+#include "VertexArray.h"
+
+namespace Aquarius {
+
+    VertexArray::VertexArray()
+    {
+
+    }
+
+    VertexArray::~VertexArray()
+    {
+
+    }
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -5,8 +5,8 @@
 
 namespace Aquarius {
 
-    VertexArray::VertexArray(const std::shared_ptr<VertexBuffer>& vertexBuffer,
-                             const std::shared_ptr<IndexBuffer>& indexBuffer,
+    VertexArray::VertexArray(std::shared_ptr<VertexBuffer> vertexBuffer,
+                             std::shared_ptr<IndexBuffer> indexBuffer,
                              const BufferLayout& bufferLayout)
             : m_VertexBuffer(vertexBuffer), m_IndexBuffer(indexBuffer)
     {
@@ -35,7 +35,7 @@ namespace Aquarius {
         glBindVertexArray(0);
     }
 
-    void VertexArray::setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer, const BufferLayout& bufferLayout)
+    void VertexArray::setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer, const BufferLayout& bufferLayout)
     {
         activate();
         vertexBuffer->Bind();
@@ -43,14 +43,14 @@ namespace Aquarius {
         setBufferLayout(bufferLayout);
     }
 
-    void VertexArray::setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer)
+    void VertexArray::setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer)
     {
         activate();
         vertexBuffer->Bind();
         m_VertexBuffer = vertexBuffer;
     }
 
-    void VertexArray::setIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)
+    void VertexArray::setIndexBuffer(std::shared_ptr<IndexBuffer> indexBuffer)
     {
         activate();
         indexBuffer->Bind();

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -1,14 +1,82 @@
 #include "VertexArray.h"
 
+#include <glad/glad.h>
+
+
 namespace Aquarius {
+
+    // TODO - What style to use here
+    VertexArray::VertexArray(const std::shared_ptr<VertexBuffer>& vertexBuffer,
+                             const std::shared_ptr<IndexBuffer>& indexBuffer,
+                             const BufferLayout& bufferLayout)
+            : m_VertexBuffer(vertexBuffer), m_IndexBuffer(indexBuffer)
+    {
+        glGenVertexArrays(1, &m_ID);
+        setIndexBuffer(indexBuffer);
+        setVertexBuffer(vertexBuffer);
+        setBufferLayout(bufferLayout);
+    }
 
     VertexArray::VertexArray()
     {
-
+        glGenVertexArrays(1, &m_ID);
     }
 
     VertexArray::~VertexArray()
     {
-
+        glDeleteVertexArrays(1, &m_ID);
     }
+
+    void VertexArray::activate()
+    {
+        glBindVertexArray(m_ID);
+    }
+
+    void VertexArray::deactivate()
+    {
+        glBindVertexArray(0);
+    }
+
+    void VertexArray::setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer)
+    {
+        m_VertexBuffer = vertexBuffer;
+        activate();
+        m_VertexBuffer->Bind();
+    }
+
+    void VertexArray::setIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)
+    {
+        m_IndexBuffer = indexBuffer;
+        activate();
+        m_IndexBuffer->Bind();
+    }
+
+    void VertexArray::setBufferLayout(const BufferLayout& bufferLayout)
+    {
+        activate();
+
+        size_t vertexAttribIndex = 0;
+        for (auto elem : bufferLayout.getElements())
+        {
+            glEnableVertexAttribArray(vertexAttribIndex);
+            glVertexAttribPointer(vertexAttribIndex,
+                                  elem.getCount(),
+                                  elem.getType(),
+                                  elem.getNormalize(),
+                                  bufferLayout.getStride(),
+                                  (void*)elem.getOffset());
+            vertexAttribIndex++;
+        }
+    }
+
+    std::shared_ptr<VertexBuffer> VertexArray::getVertexBuffer() const
+    {
+        return m_VertexBuffer;
+    }
+
+    std::shared_ptr<IndexBuffer> VertexArray::getIndexBuffer() const
+    {
+        return m_IndexBuffer;
+    }
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -5,8 +5,8 @@
 
 namespace Aquarius {
 
-    VertexArray::VertexArray(std::shared_ptr<VertexBuffer> vertexBuffer,
-                             std::shared_ptr<IndexBuffer> indexBuffer,
+    VertexArray::VertexArray(sharedPtr<VertexBuffer> vertexBuffer,
+                             sharedPtr<IndexBuffer> indexBuffer,
                              const BufferLayout& bufferLayout)
             : m_VertexBuffer(vertexBuffer), m_IndexBuffer(indexBuffer)
     {
@@ -35,7 +35,7 @@ namespace Aquarius {
         glBindVertexArray(0);
     }
 
-    void VertexArray::setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer, const BufferLayout& bufferLayout)
+    void VertexArray::setVertexBuffer(sharedPtr<VertexBuffer> vertexBuffer, const BufferLayout& bufferLayout)
     {
         activate();
         vertexBuffer->Bind();
@@ -43,14 +43,14 @@ namespace Aquarius {
         setBufferLayout(bufferLayout);
     }
 
-    void VertexArray::setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer)
+    void VertexArray::setVertexBuffer(sharedPtr<VertexBuffer> vertexBuffer)
     {
         activate();
         vertexBuffer->Bind();
         m_VertexBuffer = vertexBuffer;
     }
 
-    void VertexArray::setIndexBuffer(std::shared_ptr<IndexBuffer> indexBuffer)
+    void VertexArray::setIndexBuffer(sharedPtr<IndexBuffer> indexBuffer)
     {
         activate();
         indexBuffer->Bind();
@@ -75,12 +75,12 @@ namespace Aquarius {
         }
     }
 
-    std::shared_ptr<VertexBuffer> VertexArray::getVertexBuffer() const
+    sharedPtr<VertexBuffer> VertexArray::getVertexBuffer() const
     {
         return m_VertexBuffer;
     }
 
-    std::shared_ptr<IndexBuffer> VertexArray::getIndexBuffer() const
+    sharedPtr<IndexBuffer> VertexArray::getIndexBuffer() const
     {
         return m_IndexBuffer;
     }

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <cstdint>
+
+namespace Aquarius {
+
+    class VertexArray
+    {
+    public:
+        VertexArray();
+        ~VertexArray();
+    private:
+        uint32_t m_ID;
+    };
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Aquarius/Core/Utility.h"
 #include "Aquarius/Renderer/IndexBuffer.h"
 #include "Aquarius/Renderer/VertexBuffer.h"
 
@@ -93,26 +94,26 @@ namespace Aquarius {
     {
     public:
         VertexArray();
-        VertexArray(std::shared_ptr<VertexBuffer> vertexBuffer,
-                    std::shared_ptr<IndexBuffer> IndexBuffer,
+        VertexArray(sharedPtr<VertexBuffer> vertexBuffer,
+                    sharedPtr<IndexBuffer> IndexBuffer,
                     const BufferLayout& bufferLayout);
         ~VertexArray();
 
         void activate();
         void deactivate();
 
-        void setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer);
-        void setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer, const BufferLayout& bufferLayout);
-        void setIndexBuffer(std::shared_ptr<IndexBuffer> IndexBuffer);
+        void setVertexBuffer(sharedPtr<VertexBuffer> vertexBuffer);
+        void setVertexBuffer(sharedPtr<VertexBuffer> vertexBuffer, const BufferLayout& bufferLayout);
+        void setIndexBuffer(sharedPtr<IndexBuffer> IndexBuffer);
         void setBufferLayout(const BufferLayout& bufferLayout);
 
-        std::shared_ptr<VertexBuffer> getVertexBuffer() const;
-        std::shared_ptr<IndexBuffer> getIndexBuffer() const;
+        sharedPtr<VertexBuffer> getVertexBuffer() const;
+        sharedPtr<IndexBuffer> getIndexBuffer() const;
 
     private:
         uint32_t m_ID;
-        std::shared_ptr<VertexBuffer> m_VertexBuffer;
-        std::shared_ptr<IndexBuffer> m_IndexBuffer;
+        sharedPtr<VertexBuffer> m_VertexBuffer;
+        sharedPtr<IndexBuffer> m_IndexBuffer;
     };
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -93,17 +93,17 @@ namespace Aquarius {
     {
     public:
         VertexArray();
-        VertexArray(const std::shared_ptr<VertexBuffer>& vertexBuffer,
-                    const std::shared_ptr<IndexBuffer>& IndexBuffer,
+        VertexArray(std::shared_ptr<VertexBuffer> vertexBuffer,
+                    std::shared_ptr<IndexBuffer> IndexBuffer,
                     const BufferLayout& bufferLayout);
         ~VertexArray();
 
         void activate();
         void deactivate();
 
-        void setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer);
-        void setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer, const BufferLayout& bufferLayout);
-        void setIndexBuffer(const std::shared_ptr<IndexBuffer>& IndexBuffer);
+        void setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer);
+        void setVertexBuffer(std::shared_ptr<VertexBuffer> vertexBuffer, const BufferLayout& bufferLayout);
+        void setIndexBuffer(std::shared_ptr<IndexBuffer> IndexBuffer);
         void setBufferLayout(const BufferLayout& bufferLayout);
 
         std::shared_ptr<VertexBuffer> getVertexBuffer() const;

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -1,14 +1,118 @@
 #pragma once
+
+#include "Aquarius/Renderer/VertexBuffer.h"
+#include "Aquarius/Renderer/IndexBuffer.h"
+
 #include <cstdint>
+#include <glad/glad.h>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
 
 namespace Aquarius {
+
+    enum class ShaderType
+    {
+        Int,
+        UInt,
+        Float,
+        Double,
+    };
+
+    static const std::unordered_map<ShaderType, GLenum> ShaderTypeToGLEnum =
+    {
+        {ShaderType::Int, GL_INT},
+        {ShaderType::UInt, GL_UNSIGNED_INT},
+        {ShaderType::Float, GL_FLOAT},
+        {ShaderType::Double, GL_DOUBLE}
+    };
+
+    static const std::unordered_map<ShaderType, size_t>  ShaderTypeSizeBytes =
+    {
+            {ShaderType::Int, 4},
+            {ShaderType::UInt, 4},
+            {ShaderType::Float, 4},
+            {ShaderType::Double, 8}
+    };
+
+    class VertexElement
+    {
+    public:
+        VertexElement(ShaderType shaderType, size_t count, bool normalize)
+        {
+            m_Type = ShaderTypeToGLEnum.at(shaderType);
+            m_Count = count;
+            m_Normalize = normalize;
+            m_Size = ShaderTypeSizeBytes.at(shaderType) * m_Count;
+            m_Offset = 0;
+        }
+
+        void setOffset(size_t offset) { m_Offset = offset; }
+
+        size_t getOffset() const { return m_Offset; }
+        size_t getCount() const { return m_Count; }
+        size_t getSize() const { return m_Size; }
+        bool getNormalize() const { return m_Normalize; }
+        GLenum getType() const { return m_Type; }
+
+    private:
+        GLenum m_Type;
+        size_t m_Count;
+        size_t m_Size;
+        size_t m_Offset;
+        bool m_Normalize;
+    };
+
+
+    class BufferLayout
+    {
+    public:
+        BufferLayout(std::initializer_list<VertexElement> vertexElements)
+        {
+            // Calculate offset for each element
+            size_t Offset = 0;
+            for (auto elem : vertexElements)
+            {
+                elem.setOffset(Offset);
+                m_Elements.push_back(elem);
+                Offset += elem.getSize();
+            }
+
+            m_Stride = Offset;
+        }
+
+        const std::vector<VertexElement>& getElements() const { return m_Elements; }
+        size_t getStride() const { return m_Stride; }
+    private:
+        std::vector<VertexElement> m_Elements;
+        size_t m_Stride;
+    };
 
     class VertexArray
     {
     public:
         VertexArray();
+        VertexArray(const std::shared_ptr<VertexBuffer>& vertexBuffer,
+                    const std::shared_ptr<IndexBuffer>& IndexBuffer,
+                    const BufferLayout& bufferLayout);
         ~VertexArray();
+
+        void activate();
+        void deactivate();
+        void setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer);
+        void setIndexBuffer(const std::shared_ptr<IndexBuffer>& IndexBuffer);
+        void setBufferLayout(const BufferLayout& bufferLayout);
+
+        std::shared_ptr<VertexBuffer> getVertexBuffer() const;
+        std::shared_ptr<IndexBuffer> getIndexBuffer() const;
+
     private:
         uint32_t m_ID;
+        std::shared_ptr<VertexBuffer> m_VertexBuffer;
+        std::shared_ptr<IndexBuffer> m_IndexBuffer;
     };
+
+
+
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "Aquarius/Renderer/VertexBuffer.h"
 #include "Aquarius/Renderer/IndexBuffer.h"
+#include "Aquarius/Renderer/VertexBuffer.h"
 
 #include <cstdint>
 #include <glad/glad.h>
+#include <initializer_list>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -28,7 +29,7 @@ namespace Aquarius {
         {ShaderType::Double, GL_DOUBLE}
     };
 
-    static const std::unordered_map<ShaderType, size_t>  ShaderTypeSizeBytes =
+    static const std::unordered_map<ShaderType, uint32_t>  ShaderTypeSizeBytes =
     {
             {ShaderType::Int, 4},
             {ShaderType::UInt, 4},
@@ -39,39 +40,40 @@ namespace Aquarius {
     class VertexElement
     {
     public:
-        VertexElement(ShaderType shaderType, size_t count, bool normalize)
+        VertexElement(ShaderType shaderType, uint32_t count, bool normalize)
         {
             m_Type = ShaderTypeToGLEnum.at(shaderType);
             m_Count = count;
+            m_Size = m_Count * ShaderTypeSizeBytes.at(shaderType);
             m_Normalize = normalize;
-            m_Size = ShaderTypeSizeBytes.at(shaderType) * m_Count;
             m_Offset = 0;
         }
 
-        void setOffset(size_t offset) { m_Offset = offset; }
+        void setOffset(uint32_t offset) { m_Offset = offset; }
 
-        size_t getOffset() const { return m_Offset; }
-        size_t getCount() const { return m_Count; }
-        size_t getSize() const { return m_Size; }
+        uint32_t getOffset() const { return m_Offset; }
+        uint32_t getCount() const { return m_Count; }
+        uint32_t getSize() const { return m_Size; }
         bool getNormalize() const { return m_Normalize; }
         GLenum getType() const { return m_Type; }
 
     private:
         GLenum m_Type;
-        size_t m_Count;
-        size_t m_Size;
-        size_t m_Offset;
+        uint32_t m_Count;
+        uint32_t m_Size;
+        uint32_t m_Offset;
         bool m_Normalize;
     };
-
 
     class BufferLayout
     {
     public:
+        BufferLayout() = delete;
+        ~BufferLayout() = default;
         BufferLayout(std::initializer_list<VertexElement> vertexElements)
         {
             // Calculate offset for each element
-            size_t Offset = 0;
+            uint32_t Offset = 0;
             for (auto elem : vertexElements)
             {
                 elem.setOffset(Offset);
@@ -83,10 +85,10 @@ namespace Aquarius {
         }
 
         const std::vector<VertexElement>& getElements() const { return m_Elements; }
-        size_t getStride() const { return m_Stride; }
+        uint32_t getStride() const { return m_Stride; }
     private:
         std::vector<VertexElement> m_Elements;
-        size_t m_Stride;
+        uint32_t m_Stride;
     };
 
     class VertexArray
@@ -100,7 +102,9 @@ namespace Aquarius {
 
         void activate();
         void deactivate();
+
         void setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer);
+        void setVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer, const BufferLayout& bufferLayout);
         void setIndexBuffer(const std::shared_ptr<IndexBuffer>& IndexBuffer);
         void setBufferLayout(const BufferLayout& bufferLayout);
 
@@ -112,7 +116,5 @@ namespace Aquarius {
         std::shared_ptr<VertexBuffer> m_VertexBuffer;
         std::shared_ptr<IndexBuffer> m_IndexBuffer;
     };
-
-
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -21,20 +21,18 @@ namespace Aquarius {
         Double,
     };
 
-    static const std::unordered_map<ShaderType, GLenum> ShaderTypeToGLEnum =
+    static struct ShaderTypeInfo
     {
-        {ShaderType::Int, GL_INT},
-        {ShaderType::UInt, GL_UNSIGNED_INT},
-        {ShaderType::Float, GL_FLOAT},
-        {ShaderType::Double, GL_DOUBLE}
+        GLenum glType;
+        uint32_t size;
     };
 
-    static const std::unordered_map<ShaderType, uint32_t>  ShaderTypeSizeBytes =
+    static const std::unordered_map<ShaderType, ShaderTypeInfo> ShaderTypeInfoMap =
     {
-            {ShaderType::Int, 4},
-            {ShaderType::UInt, 4},
-            {ShaderType::Float, 4},
-            {ShaderType::Double, 8}
+        {ShaderType::Int, {GL_INT, 4}},
+        {ShaderType::UInt, {GL_UNSIGNED_INT, 4}},
+        {ShaderType::Float, {GL_FLOAT, 4}},
+        {ShaderType::Double, {GL_DOUBLE, 8}}
     };
 
     class VertexElement
@@ -42,9 +40,9 @@ namespace Aquarius {
     public:
         VertexElement(ShaderType shaderType, uint32_t count, bool normalize)
         {
-            m_Type = ShaderTypeToGLEnum.at(shaderType);
+            m_Type = ShaderTypeInfoMap.at(shaderType).glType;
             m_Count = count;
-            m_Size = m_Count * ShaderTypeSizeBytes.at(shaderType);
+            m_Size = m_Count * ShaderTypeInfoMap.at(shaderType).size;
             m_Normalize = normalize;
             m_Offset = 0;
         }

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -21,7 +21,7 @@ namespace Aquarius {
         Double,
     };
 
-    static struct ShaderTypeInfo
+    struct ShaderTypeInfo
     {
         GLenum glType;
         uint32_t size;
@@ -68,14 +68,14 @@ namespace Aquarius {
     public:
         BufferLayout() = delete;
         ~BufferLayout() = default;
-        BufferLayout(std::initializer_list<VertexElement> vertexElements)
+        BufferLayout(const std::initializer_list<VertexElement>& vertexElements)
         {
             // Calculate offset for each element
             uint32_t Offset = 0;
             for (auto elem : vertexElements)
             {
                 elem.setOffset(Offset);
-                m_Elements.push_back(elem);
+                m_Elements.push_back(std::move(elem));
                 Offset += elem.getSize();
             }
 

--- a/Sandbox/Shaders/fragmentShader.glsl
+++ b/Sandbox/Shaders/fragmentShader.glsl
@@ -2,9 +2,9 @@
 
 // Basic Fragment Shader
 out vec4 FragColor;
-uniform vec4 color;
+in vec3 fColor;
 
 void main()
 {
-     FragColor = color;
+     FragColor = vec4(fColor, 1.0);
 }

--- a/Sandbox/Shaders/vertexShader.glsl
+++ b/Sandbox/Shaders/vertexShader.glsl
@@ -2,8 +2,12 @@
 
 // Basic Vertex Shader
 layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec3 aColor;
+
+out vec3 fColor;
 
 void main()
 {
    gl_Position = vec4(aPos.x, aPos.y, 0.0, 1.0);
+   fColor = aColor;
 }


### PR DESCRIPTION
This PR adds abstraction of the OpenGL vertex array object, using 3 classes. The vertex array object stores a state which includes a bound vertex buffer, index buffer, and most importantly vertex buffer layout which tells the GPU how to interpret the data in the vertex buffer.

You can create a VAO, add a vertex and index buffer, then set the layout (there is also the option to construct the VAO with the buffers and the layout).

I did some interesting things to get the GLenum type, creating a map between types I defined and types defined in GLenum so that the client doesn't need glad to create a buffer layout.

## Summary

### VAO
- Encapsulates creating VAO, adding index/vertex buffers, and setting the vertex buffer layout

### BufferLayout
- Defines the Vertex attribute layout for a certain vertex buffer, contains a vector of VertexElements. On construction will calculate the offset of each element and the stride

### VertexElement
- Defines a single vertex element with the type of elements, the number of elements, and if the elements should be normalized.

There's some interesting things in here, would love some feedback!  