### PR TITLE
Add Barebones Renderer Implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ cmake-build-debug/
 
 # Python venv
 .venv
+
+# Logs
+*.log

--- a/Aquarius/Aquarius.cpp
+++ b/Aquarius/Aquarius.cpp
@@ -72,9 +72,9 @@ namespace Aquarius {
         // Render loop
         while (1)
         {
-            glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
-            glClear(GL_COLOR_BUFFER_BIT);
-            glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, (void*)0);
+            Renderer::ClearColor({0.2, 0.3, 0.7});
+            Renderer::Clear();
+            Renderer::Submit(&VA0, &shaderProgram);
             Window->OnUpdate();
         }
 

--- a/Aquarius/Aquarius.h
+++ b/Aquarius/Aquarius.h
@@ -9,6 +9,7 @@
 #include "Aquarius/Core/Window.h"
 
 // -- Renderer
+#include "Aquarius/Renderer/Renderer.h"
 #include "Aquarius/Renderer/IndexBuffer.h"
 #include "Aquarius/Renderer/VertexBuffer.h"
 #include "Aquarius/Renderer/VertexArray.h"

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
@@ -33,4 +33,4 @@ namespace Aquarius {
         glDrawElements(GL_TRIANGLES, vertexArray->getIndexBuffer()->getCount(), GL_UNSIGNED_INT, (void*)0);
     }
 
-}
+} // namespace Aquarius 

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
@@ -1,0 +1,36 @@
+#include "Renderer.h"
+#include "Aquarius/Core/Application.h"
+
+#include <glad/glad.h>
+
+
+namespace Aquarius {
+
+    void Renderer::Init()
+    {
+        glPolygonMode(GL_FRONT, GL_FILL);
+    }
+
+    void Renderer::Shutdown()
+    {
+        // Nothing to put here just yet
+    }
+
+    void Renderer::Clear()
+    {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    }
+
+    void Renderer::ClearColor(glm::vec3 color)
+    {
+        glClearColor(color.x, color.y, color.z, 1.0f);
+    }
+
+    void Renderer::Submit(VertexArray* vertexArray, Shader* shader)
+    {
+        shader->activate();
+        vertexArray->activate();
+        glDrawElements(GL_TRIANGLES, vertexArray->getIndexBuffer()->getCount(), GL_UNSIGNED_INT, (void*)0);
+    }
+
+}

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
@@ -6,31 +6,35 @@
 
 namespace Aquarius {
 
-    void Renderer::Init()
-    {
-        glPolygonMode(GL_FRONT, GL_FILL);
-    }
+        namespace Renderer {
 
-    void Renderer::Shutdown()
-    {
-        // Nothing to put here just yet
-    }
+            void Init()
+            {
+                glPolygonMode(GL_FRONT, GL_FILL);
+            }
 
-    void Renderer::Clear()
-    {
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    }
+            void Shutdown()
+            {
+                // Nothing to put here just yet
+            }
 
-    void Renderer::ClearColor(glm::vec3 color)
-    {
-        glClearColor(color.x, color.y, color.z, 1.0f);
-    }
+            void Clear()
+            {
+                glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            }
 
-    void Renderer::Submit(VertexArray* vertexArray, Shader* shader)
-    {
-        shader->activate();
-        vertexArray->activate();
-        glDrawElements(GL_TRIANGLES, vertexArray->getIndexBuffer()->getCount(), GL_UNSIGNED_INT, (void*)0);
-    }
+            void ClearColor(glm::vec3 color)
+            {
+                glClearColor(color.x, color.y, color.z, 1.0f);
+            }
+
+            void Submit(VertexArray* vertexArray, Shader* shader)
+            {
+                shader->activate();
+                vertexArray->activate();
+                glDrawElements(GL_TRIANGLES, vertexArray->getIndexBuffer()->getCount(), GL_UNSIGNED_INT, (void*)0);
+            }
+
+        } // namespace Renderer
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.cpp
@@ -33,4 +33,4 @@ namespace Aquarius {
         glDrawElements(GL_TRIANGLES, vertexArray->getIndexBuffer()->getCount(), GL_UNSIGNED_INT, (void*)0);
     }
 
-} // namespace Aquarius 
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.h
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.h
@@ -24,4 +24,4 @@ namespace Aquarius {
         static void Submit(VertexArray* vertexArray, Shader* shader);
     };
 
-}
+} // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.h
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Aquarius/Renderer/VertexArray.h"
+#include "Aquarius/Renderer/IndexBuffer.h"
+#include "Aquarius/Renderer/Shader.h"
+
+#include <glm/glm.hpp>
+
+namespace Aquarius {
+
+    class Renderer
+    {
+    public:
+        Renderer() = delete;
+        ~Renderer() = delete;
+
+        static void Init();
+        static void Shutdown();
+
+        static void Clear();
+        static void ClearColor(glm::vec3 color);
+
+        static void Submit(VertexArray* vertexArray, Shader* shader);
+    };
+
+}

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.h
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.h
@@ -13,7 +13,7 @@ namespace Aquarius {
     {
     public:
         Renderer() = delete;
-        ~Renderer() = delete;
+        ~Renderer() = default;
 
         static void Init();
         static void Shutdown();

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.h
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.h
@@ -6,6 +6,7 @@
 
 #include <glm/glm.hpp>
 
+
 namespace Aquarius {
 
     class Renderer

--- a/Aquarius/Src/Aquarius/Renderer/Renderer.h
+++ b/Aquarius/Src/Aquarius/Renderer/Renderer.h
@@ -9,19 +9,16 @@
 
 namespace Aquarius {
 
-    class Renderer
-    {
-    public:
-        Renderer() = delete;
-        ~Renderer() = default;
+    namespace Renderer {
 
-        static void Init();
-        static void Shutdown();
+        void Init();
+        void Shutdown();
 
-        static void Clear();
-        static void ClearColor(glm::vec3 color);
+        void Clear();
+        void ClearColor(glm::vec3 color);
 
-        static void Submit(VertexArray* vertexArray, Shader* shader);
-    };
+        void Submit(VertexArray* vertexArray, Shader* shader);
+
+    } // namespace Renderer
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.cpp
@@ -75,14 +75,14 @@ namespace Aquarius {
         }
     }
 
-    sharedPtr<VertexBuffer> VertexArray::getVertexBuffer() const
+    VertexBuffer* VertexArray::getVertexBuffer() const
     {
-        return m_VertexBuffer;
+        return m_VertexBuffer.get();
     }
 
-    sharedPtr<IndexBuffer> VertexArray::getIndexBuffer() const
+    IndexBuffer* VertexArray::getIndexBuffer() const
     {
-        return m_IndexBuffer;
+        return m_IndexBuffer.get();
     }
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/VertexArray.h
+++ b/Aquarius/Src/Aquarius/Renderer/VertexArray.h
@@ -107,8 +107,8 @@ namespace Aquarius {
         void setIndexBuffer(sharedPtr<IndexBuffer> IndexBuffer);
         void setBufferLayout(const BufferLayout& bufferLayout);
 
-        sharedPtr<VertexBuffer> getVertexBuffer() const;
-        sharedPtr<IndexBuffer> getIndexBuffer() const;
+        VertexBuffer* getVertexBuffer() const;
+        IndexBuffer* getIndexBuffer() const;
 
     private:
         uint32_t m_ID;


### PR DESCRIPTION
Something to build off of, adds a static only renderer class with a submit method for drawing a provided VAO to the screen. Altered the test code in the testTriangle method as well. I plan on extending this renderer to include calls for drawing quads using screen space coordinates (pixel values between screen width and height) instead of using NDC all the time. 

@Burke-Daniel You could probably rebase on this and use the renderer calls inside SandboxLayer.
