### PR TITLE
Generate Visual Studio Project Files w/ CMake

### DIFF
--- a/Aquarius/CMakeLists.txt
+++ b/Aquarius/CMakeLists.txt
@@ -6,11 +6,22 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_definitions(-DGLFW_INCLUDE_NONE)
 
-file(GLOB_RECURSE Sources "Src/*.cpp" "Src/*.h")
+file(GLOB_RECURSE CORE_SOURCES "Src/Aquarius/Core/*.cpp" "Src/Aquarius/Core/*.h")
+file(GLOB_RECURSE EVENT_SOURCES "Src/Aquarius/Events/*.cpp" "Src/Aquarius/Events/*.h")
+file(GLOB_RECURSE RENDERER_SOURCES "Src/Aquarius/Renderer/*.cpp" "Src/Aquarius/Renderer/*.h")
+set(TOP_LEVEL_FILES "Aquarius.h")
+
+source_group("" FILES ${TOP_LEVEL_FILES})
+source_group("Core" FILES ${CORE_SOURCES})
+source_group("Events" FILES ${EVENT_SOURCES})
+source_group("Renderer" FILES  ${RENDERER_SOURCES})
 
 include_directories(Src/)
 
-add_library(Aquarius-Engine STATIC ${Sources} Aquarius.h)
+add_library(Aquarius-Engine STATIC  ${TOP_LEVEL_FILES} 
+									${CORE_SOURCES} 
+									${EVENT_SOURCES} 
+									${RENDERER_SOURCES})
 
 target_link_libraries(Aquarius-Engine glad)
 target_link_libraries(Aquarius-Engine glfw ${GLFW_LIBRARIES})


### PR DESCRIPTION
Quick PR making the lives of Visual Studio users a little easier - generate filters that match the actual src tree with cmake. I find it nicer to have it organized like this instead of "Header/" and "Source/" like the default filters. 

LMK what you guys think, and @liamjwarren definitely test it on mac / CLion. Worried it might break on MAC seeing how visual studio isn't a thing there. I can probably add an "IF MSVC" or something