### PR TITLE
Window Resize

### DIFF
--- a/Aquarius/Src/Aquarius/Core/Application.cpp
+++ b/Aquarius/Src/Aquarius/Core/Application.cpp
@@ -1,6 +1,8 @@
 #include "Application.h"
 #include "Aquarius/Core/Input.h"
 #include "Aquarius/Core/Log.h"
+#include "Aquarius/Events/WindowEvent.h"
+#include "Aquarius/Renderer/Renderer.h"
 
 #include <chrono>
 
@@ -24,6 +26,13 @@ namespace Aquarius {
 		m_Window->Initialize();
 
 		AQ_CORE_INFO("Window Initialized Successfully");
+
+		// Register window resize event
+		m_EventHandler.subscribe(Aquarius::eventType::WindowResizedEvent,
+			[&](const Aquarius::Event& event)
+			{
+				onWindowResize(event);
+			});
 	}
 
 	void Application::run()
@@ -48,7 +57,13 @@ namespace Aquarius {
 	void Application::onEvent(Event &event)
 	{
 	    m_EventHandler.notify(event);
-  }
+    }
+
+	void Application::onWindowResize(const Event& event)
+	{
+		auto e = static_cast<const Aquarius::WindowResizedEvent&>(event);
+		glViewport(0, 0, e.getWidth(), e.getHeight());
+	}
 
 	Layer* Application::PushLayer(uniquePtr<Layer> layer)
 	{

--- a/Aquarius/Src/Aquarius/Core/Application.h
+++ b/Aquarius/Src/Aquarius/Core/Application.h
@@ -29,6 +29,7 @@ namespace Aquarius {
 		void run();
 
 		void onEvent(Event& event);
+		void onWindowResize(const Event& event);
 
 		Layer* PushLayer(uniquePtr<Layer> layer);
 

--- a/Aquarius/Src/Aquarius/Core/Window.cpp
+++ b/Aquarius/Src/Aquarius/Core/Window.cpp
@@ -1,4 +1,5 @@
 #include "Window.h"
+
 #include "Aquarius/Core/Input.h"
 #include "Aquarius/Core/Log.h"
 #include "Aquarius/Events/Callbacks.h"
@@ -72,6 +73,13 @@ namespace Aquarius {
 
         glfwSetInputMode(m_Window, GLFW_STICKY_MOUSE_BUTTONS, 1);
         glfwSetInputMode(m_Window, GLFW_STICKY_KEYS,1);
+
+        // Register window resize event
+        Application::get()->getEventHandler().subscribe(eventType::WindowResizedEvent,
+            [&](const Event& event)
+            {
+                onWindowResize(event);
+            });
     }
 
     uint32_t Window::getWidth() const
@@ -131,6 +139,13 @@ namespace Aquarius {
             AQ_CORE_INFO("Vsync disabled");
         }
         m_VsyncEnabled = enabled;
+    }
+
+    void Window::onWindowResize(const Event& event)
+    {
+        auto windowResizeEvent = static_cast<const WindowResizedEvent&>(event);
+        m_Height = windowResizeEvent.getHeight();
+        m_Width = windowResizeEvent.getWidth();
     }
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Core/Window.h
+++ b/Aquarius/Src/Aquarius/Core/Window.h
@@ -9,6 +9,7 @@
 
 
 namespace Aquarius {
+    class Event;
 
     class Window
     {
@@ -22,6 +23,7 @@ namespace Aquarius {
 
         // Poll inputs and swap buffers
         void OnUpdate();
+        void onWindowResize(const Event& event);
 
         // Utility methods
         uint32_t getWidth() const;

--- a/Aquarius/Src/Aquarius/Events/WindowEvent.h
+++ b/Aquarius/Src/Aquarius/Events/WindowEvent.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "Event.h"
+#include "Aquarius/Events/Event.h"
+#include "Aquarius/Core/Log.h"
 
 
 namespace Aquarius {

--- a/Aquarius/Src/Aquarius/Renderer/OrthographicCamera.cpp
+++ b/Aquarius/Src/Aquarius/Renderer/OrthographicCamera.cpp
@@ -1,5 +1,9 @@
 #include "OrthographicCamera.h"
 
+#include "Aquarius/Core/Application.h"
+#include "Aquarius/Events/WindowEvent.h"
+
+
 namespace Aquarius {
 
     OrthographicCamera::OrthographicCamera(float moveSpeed, float zoomSpeed, float height, float width)
@@ -14,6 +18,12 @@ namespace Aquarius {
     {
         updateView();
         updateProjection();
+
+        Application::get()->getEventHandler().subscribe(Aquarius::eventType::WindowResizedEvent,
+            [&](const Aquarius::Event& event)
+            {
+                onWindowResize(event);
+            });
     }
 
     void OrthographicCamera::onUpdate(timeDelta_t dt)
@@ -80,6 +90,16 @@ namespace Aquarius {
     void OrthographicCamera::updateProjection()
     {
         m_Projection = glm::ortho(0.0f, m_Width, m_Height, 0.0f, -1.0f, 1.0f);
+    }
+
+    void OrthographicCamera::onWindowResize(const Event& event)
+    {
+        auto e = static_cast<const Aquarius::WindowResizedEvent&>(event);
+        m_Width = e.getWidth();
+        m_Height = e.getHeight();
+
+        updateProjection();
+        updateView();
     }
 
 } // namespace Aquarius

--- a/Aquarius/Src/Aquarius/Renderer/OrthographicCamera.h
+++ b/Aquarius/Src/Aquarius/Renderer/OrthographicCamera.h
@@ -3,6 +3,7 @@
 #include "Aquarius/Core/Input.h"
 #include "Aquarius/Core/Utility.h"
 #include "Aquarius/Core/Log.h"
+#include "Aquarius/Events/Event.h"
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -17,6 +18,7 @@ namespace Aquarius {
 		~OrthographicCamera() = default;
 
 		void onUpdate(timeDelta_t dt);
+		void onWindowResize(const Event& event);
 		void updateView();
 		void updateProjection();
 

--- a/Sandbox/PongLayer.cpp
+++ b/Sandbox/PongLayer.cpp
@@ -32,8 +32,6 @@ void PongLayer::onCreation()
 	int height = window.getHeight();
 	int width = window.getWidth();
 
-	glfwSetInputMode(window.get(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-
 	m_Camera = std::make_shared<Aquarius::OrthographicCamera>(1, 0.01, height, width);
 	Aquarius::Renderer::Init();
 


### PR DESCRIPTION
## Brief
Using WindowResizedEvent-regsistered callbacks, perform appropriate operations when the window is resized.

## Summary
- Add callback in `Application.cpp` to update the viewport size when the window is resized
- Add callback in `Camera.cpp` to update the projection matrix when the window is resized
- Add callback in Window to update the window width and height when the window is resized
- In `PongLayer.cpp`, remove the call to disable cursor